### PR TITLE
Ignore Jupyter in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,10 @@
 ###############################################################################
 * text=auto
 
+# Override jupyter in Github language stats for more accurate estimate of repo code
+# reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+*.ipynb linguist-generated
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #


### PR DESCRIPTION
Small change to .gitattributes file to manually override how Github counts lines from Jupyter files. This gives more accurate code statistics for the repo. 

Instructions taken from https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code, referenced in discussion under https://github.com/github/linguist/issues/3316 (official github-linguist repo). 