### PR TITLE
Let dependabot track nuget dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,12 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 3
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: "saturday"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
There are a bunch of code scanning issues (e.g., https://github.com/orcasound/aifororcas-livesystem/security/code-scanning/54)  found in this repository under the Security tab.  Most appear to be due to outdated nuget packages.  Dependabot already tracks github actions, but not nuget package dependencies.

As the new lead for the NotificationSystem subsystem (and the old lead for github infrastructure), I want to enable them on at least the NotificationSystem subsystem.  If others don't want them on other subsystems, I can update this PR to restrict the directory to only NotificationSystem.