### PR TITLE
Fix dependabot for nuget for NotificationSystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
           - "*"
     open-pull-requests-limit: 3
   - package-ecosystem: nuget
-    directory: /
+    directory: "/NotificationSystem"
     schedule:
       interval: weekly
       day: "saturday"


### PR DESCRIPTION
Dependabot configuration now has a nuget section, but the logs https://github.com/orcasound/aifororcas-livesystem/actions/runs/17562171054/job/49880912201 show that it still isn't find the NotificationSystem code to scan.

Turns out that dependabot doesn't recursively look under specified directories, it requires you to explicitly list each directory with a .sln file to use.