### PR TITLE
Fix ability to post to orcasite unmoderated detections

### DIFF
--- a/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
+++ b/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
@@ -234,13 +234,12 @@ namespace NotificationSystem.Models
                 return false;
             }
 
-            // Get comments from OrcaHello.
-            if (!orcaHelloDetection.TryGetProperty("comments", out var comments))
+            // Get comments from OrcaHello.  This property will only be present
+            // if the detection was already moderated within OrcaHello.
+            if (orcaHelloDetection.TryGetProperty("comments", out var comments))
             {
-                _logger.LogError($"Missing comments in ExecuteTask result");
-                return false;
+                commentsString = comments.ValueKind == JsonValueKind.String ? comments.GetString() : null;
             }
-            commentsString = comments.ValueKind == JsonValueKind.String ? comments.GetString() : null;
             return true;
         }
 


### PR DESCRIPTION
The "comments" property is only present in an orcahello detection once it has been moderated.

Previously the code treated it as required, assuming it would be present but null in an unmoderated case (there were none in the database to test with), but that assumption was incorrect.

This PR updates the parsing code so that the comments property is optional.