### PR TITLE
Add CI workflow step to test the built docker container

### DIFF
--- a/.github/workflows/InferenceSystem.yaml
+++ b/.github/workflows/InferenceSystem.yaml
@@ -232,7 +232,8 @@ jobs:
           live-inference-system \
           python3 -u ./src/LiveInferenceOrchestrator.py \
           --config /config/Test/FastAI_LiveHLS_OrcasoundLab.yml \
-          --max_iterations 2
+          --max_iterations 2 | tee output.log
+        test "$(grep -c "global_prediction" output.log)" -eq 2
 
     - name: Save docker container to tar file
       working-directory: InferenceSystem

--- a/InferenceSystem/README.md
+++ b/InferenceSystem/README.md
@@ -217,12 +217,12 @@ From the `InferenceSystem` directory, run the following command. You need to spe
 
 Linux:
 ```
-docker run --rm -it --env-file .env -v $PWD/config:/config live-inference-system python3 -u ./src/LiveInferenceOrchestrator.py --config ./config/Test/FastAI_LiveHLS_OrcasoundLab.yml
+docker run --rm -it --env-file .env -v $PWD/config:/config live-inference-system python3 -u ./src/LiveInferenceOrchestrator.py --config /config/Test/FastAI_LiveHLS_OrcasoundLab.yml
 ```
 
 Windows:
 ```
-docker run --rm -it --env-file .env -v %cd%/config:/config live-inference-system python3 -u ./src/LiveInferenceOrchestrator.py --config ./config/Test/FastAI_LiveHLS_OrcasoundLab.yml
+docker run --rm -it --env-file .env -v %cd%/config:/config live-inference-system python3 -u ./src/LiveInferenceOrchestrator.py --config /config/Test/FastAI_LiveHLS_OrcasoundLab.yml
 ```
 
 **Note:** When deployed to Kubernetes, the container automatically detects its namespace and loads the configuration from the ConfigMap. The `--config` argument is only needed for local testing.


### PR DESCRIPTION
Non-container functionality was tested in CI on both windows and ubuntu.
But the tests only built the docker container, it was not run to verify it works.