### PR TITLE
Add location to subscriber notifications

### DIFF
--- a/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
@@ -251,7 +251,8 @@ namespace NotificationSystem.Tests.Unit
             };
 
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(messages);
+            string location = EmailTemplate.GetLocation(messages);
+            string subject = EmailTemplate.GetSubscriberEmailSubject(location);
 
             // Assert
             Assert.Equal("Notification: Orca detected at location Sunset Bay", subject);
@@ -282,17 +283,18 @@ namespace NotificationSystem.Tests.Unit
             };
 
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(messages);
+            string location = EmailTemplate.GetLocation(messages);
+            string subject = EmailTemplate.GetSubscriberEmailSubject(location);
 
             // Assert
             Assert.Equal("Notification: Orca detected at location Unknown", subject);
         }
 
         /// <summary>
-        /// Tests that GetSubscriberEmailSubject handles null location with "Unknown".
+        /// Tests that GetLocation handles null location.
         /// </summary>
         [Fact]
-        public void GetSubscriberEmailSubject_HandlesNullLocation()
+        public void GetLocation_HandlesNullLocation()
         {
             // Arrange
             var messages = new List<JObject>
@@ -306,46 +308,49 @@ namespace NotificationSystem.Tests.Unit
             };
 
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(messages);
+            string location = EmailTemplate.GetLocation(messages);
 
             // Assert
-            Assert.Equal("Notification: Orca detected at location Unknown", subject);
+            Assert.Null(location);
         }
 
         /// <summary>
-        /// Tests that GetSubscriberEmailSubject handles empty message list.
+        /// Tests that GetLocation handles empty message list.
+        /// TODO(issue #356): remove this test once the API is updated to use a singleton.
         /// </summary>
         [Fact]
-        public void GetSubscriberEmailSubject_HandlesEmptyMessageList()
+        public void GetLocation_HandlesEmptyMessageList()
         {
             // Arrange
             var messages = new List<JObject>();
 
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(messages);
+            string location = EmailTemplate.GetLocation(messages);
 
             // Assert
-            Assert.Equal("Notification: Orca detected!", subject);
+            Assert.Null(location);
         }
 
         /// <summary>
-        /// Tests that GetSubscriberEmailSubject handles null message list.
+        /// Tests that GetLocation handles null message list.
+        /// TODO(issue #356): remove this test once the API is updated to use a singleton.
         /// </summary>
         [Fact]
-        public void GetSubscriberEmailSubject_HandlesNullMessageList()
+        public void GetLocation_HandlesNullMessageList()
         {
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(null);
+            string location = EmailTemplate.GetLocation(null);
 
             // Assert
-            Assert.Equal("Notification: Orca detected!", subject);
+            Assert.Null(location);
         }
 
         /// <summary>
-        /// Tests that GetSubscriberEmailSubject uses first location when multiple messages exist.
+        /// Tests that GetLocation uses first location when multiple messages exist.
+        /// TODO(issue #356): remove this test once the API is updated to use a singleton.
         /// </summary>
         [Fact]
-        public void GetSubscriberEmailSubject_UsesFirstLocationForMultipleMessages()
+        public void GetLocation_UsesFirstLocationForMultipleMessages()
         {
             // Arrange
             var messages = new List<JObject>
@@ -379,10 +384,10 @@ namespace NotificationSystem.Tests.Unit
             };
 
             // Act
-            string subject = EmailTemplate.GetSubscriberEmailSubject(messages);
+            string location = EmailTemplate.GetLocation(messages);
 
             // Assert
-            Assert.Equal("Notification: Orca detected at location Sunset Bay", subject);
+            Assert.Equal("Sunset Bay", location);
         }
     }
 }

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -19,24 +19,27 @@ namespace NotificationSystem.Template
             return $"<html><head><style>{GetCSS()}</style></head><body>{GetSubscriberEmailHtml(messages, orcasiteHelper)}</body></html>";
         }
 
-        public static string GetSubscriberEmailSubject(List<JObject> messages)
+        public static string GetLocation(List<JObject> messages)
         {
             if (messages == null || messages.Count == 0)
             {
-                return "Notification: Orca detected!";
+                return null;
             }
 
             // Extract location from first message
             string location = null;
             try
             {
-                location = messages[0]["location"]?["name"]?.ToString();
+                return messages[0]["location"]?["name"]?.ToString();
             }
             catch
             {
-                // If we can't get location, use null which will default to "Unknown"
+                return null;
             }
+        }
 
+        public static string GetSubscriberEmailSubject(string location)
+        {
             return $"Notification: Orca detected at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
         }
 


### PR DESCRIPTION
Location was added to moderator notifications, which was issue #229.  This PR does the same for subscriber notifications.