### PR TITLE
Apply startup delay offset when fixing legacy timestamps

### DIFF
--- a/NotificationSystem/NotificationSystem.Tests.Unit/OrcasiteTestHelper.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/OrcasiteTestHelper.cs
@@ -62,11 +62,11 @@ namespace NotificationSystem.Tests.Common
             string sampleOrcasitePostDetectionResponse = GetStringFromFile("OrcasitePostDetectionResponse.json");
 
             // Mock the GET request to fetch feeds.
-            var getFeedsRequest = mockHttp.When(HttpMethod.Get, "https://beta.orcasound.net/api/json/feeds?fields%5Bfeed%5D=id%2Cname%2Cnode_name%2Cslug%2Clocation_point%2Cintro_html%2Cimage_url%2Cvisible%2Cbucket%2Cbucket_region%2Ccloudfront_url%2Cdataplicity_id%2Corcahello_id")
+            var getFeedsRequest = mockHttp.When(HttpMethod.Get, "https://*.orcasound.net/api/json/feeds?fields%5Bfeed%5D=id%2Cname%2Cnode_name%2Cslug%2Clocation_point%2Cintro_html%2Cimage_url%2Cvisible%2Cbucket%2Cbucket_region%2Ccloudfront_url%2Cdataplicity_id%2Corcahello_id")
                     .Respond("application/json", sampleOrcasiteFeeds);
 
             // Mock the POST request to create a detection.
-            var postDetectionRequest = mockHttp.When(HttpMethod.Post, "https://beta.orcasound.net/api/json/detections?fields%5Bdetection%5D=id%2Csource_ip%2Cplaylist_timestamp%2Cplayer_offset%2Clistener_count%2Ctimestamp%2Cdescription%2Cvisible%2Csource%2Ccategory%2Ccandidate_id%2Cfeed_id")
+            var postDetectionRequest = mockHttp.When(HttpMethod.Post, "https://*.orcasound.net/api/json/detections?fields%5Bdetection%5D=id%2Csource_ip%2Cplaylist_timestamp%2Cplayer_offset%2Clistener_count%2Ctimestamp%2Cdescription%2Cvisible%2Csource%2Ccategory%2Ccandidate_id%2Cfeed_id")
                     //.WithContent("{\"key\":\"value\"}") // Optional: match request body
                     .Respond(HttpStatusCode.Created, "application/json", sampleOrcasitePostDetectionResponse);
 

--- a/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
+++ b/NotificationSystem/NotificationSystem/Models/OrcasiteHelper.cs
@@ -570,7 +570,9 @@ namespace NotificationSystem.Models
 
                 // Fix the Unix time.  The originalDateTime is incorrect and
                 // was computed based on clips being 11 seconds long instead
-                // of 10 seconds long.  We can correct this once we know the
+                // of 10 seconds long.  It is also based on the audio stream
+                // starting as of the .ts folder date, instead of about 2 seconds
+                // afterwards.  We can correct these once we know the
                 // .ts folder date to start calculating the drift based on.
 
                 string locationIdString = TryGetLocationIdString(originalDetection);
@@ -601,7 +603,7 @@ namespace NotificationSystem.Models
 
                 long originalSecondsIntoFolder = originalUnixTimeSeconds - folderTimeSeconds;
                 long originalClipIndex = originalSecondsIntoFolder / 11;
-                long correctedSecondsIntoFolder = originalClipIndex * 10;
+                long correctedSecondsIntoFolder = originalClipIndex * 10 + 2;
                 long correctedUnixTimeSeconds = folderTimeSeconds + correctedSecondsIntoFolder;
                 DateTimeOffset correctedDateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(correctedUnixTimeSeconds);
                 string correctedTimestampString = correctedDateTimeOffset.ToUniversalTime()


### PR DESCRIPTION
From analysis of past data there is a 2 second delay between the S3 folder timestamp and the start of an audio stream.

Fixes #353