### PR TITLE
Update andrews-bay, north-sjc and point-robinson deployment files

### DIFF
--- a/InferenceSystem/deploy/andrews-bay.yaml
+++ b/InferenceSystem/deploy/andrews-bay.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: inference-system
-        image: orcaconservancycr.azurecr.io/live-inference-system:10-08-2025.FastAI.R1-12.v0
+        image: orcaconservancycr.azurecr.io/live-inference-system:11-19-2025.FastAI.R1-12.v0
         resources:
           limits:
             cpu: 1

--- a/InferenceSystem/deploy/north-sjc.yaml
+++ b/InferenceSystem/deploy/north-sjc.yaml
@@ -15,10 +15,7 @@ spec:
     spec:
       containers:
       - name: inference-system
-        # NOTE: This is the old hydrophone-specific image. When using the new common container image,
-        # update to a tag without the hydrophone location suffix (e.g., 11-15-20.FastAI.R1-12.v0)
-        # The container will automatically detect the namespace and load the config from ConfigMap.
-        image: orcaconservancycr.azurecr.io/live-inference-system:09-19-24.FastAI.R1-12.NorthSJC.v0
+        image: orcaconservancycr.azurecr.io/live-inference-system:11-19-2025.FastAI.R1-12.v0
         resources:
           limits:
             cpu: 1

--- a/InferenceSystem/deploy/point-robinson.yaml
+++ b/InferenceSystem/deploy/point-robinson.yaml
@@ -15,10 +15,7 @@ spec:
     spec:
       containers:
       - name: inference-system
-        # NOTE: This is the old hydrophone-specific image. When using the new common container image,
-        # update to a tag without the hydrophone location suffix (e.g., 11-15-20.FastAI.R1-12.v0)
-        # The container will automatically detect the namespace and load the config from ConfigMap.
-        image: orcaconservancycr.azurecr.io/live-inference-system:09-18-24.FastAI.R1-12.PointRobinson.v0
+        image: orcaconservancycr.azurecr.io/live-inference-system:11-19-2025.FastAI.R1-12.v0
         resources:
           limits:
             cpu: 1

--- a/InferenceSystem/requirements.txt
+++ b/InferenceSystem/requirements.txt
@@ -25,4 +25,4 @@ opencv-python
 boto3
 pytz
 opencensus-ext-azure
-orca-hls-utils>=0.0.3
+orca-hls-utils>=0.0.4


### PR DESCRIPTION
* Update orca-hls-utils to minimum version 0.0.4
* Update deployment files for three nodes (the ones that aren't present streaming real audio) to use a new container image

andrews-bay and point-robinson are now deployed, and streaming silence.  (andrews-bay hydrophone should go online shortly)
north-sjc is stopped (since there's no stream there at present).
Leaving the other streams untouched for a few more days to observe andrews-bay and point-robinson to build confidence first.