### PR TITLE
Make inference system script run single-threaded

### DIFF
--- a/InferenceSystem/deploy/andrews-bay.yaml
+++ b/InferenceSystem/deploy/andrews-bay.yaml
@@ -36,6 +36,10 @@ spec:
               secretKeyRef:
                 name: inference-system
                 key: INFERENCESYSTEM_APPINSIGHTS_CONNECTION_STRING
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MKL_NUM_THREADS
+            value: "1"
         volumeMounts:
           - name: config-volume
             mountPath: /config

--- a/InferenceSystem/deploy/north-sjc.yaml
+++ b/InferenceSystem/deploy/north-sjc.yaml
@@ -36,6 +36,10 @@ spec:
               secretKeyRef:
                 name: inference-system
                 key: INFERENCESYSTEM_APPINSIGHTS_CONNECTION_STRING
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MKL_NUM_THREADS
+            value: "1"
         volumeMounts:
           - name: config-volume
             mountPath: /config

--- a/InferenceSystem/deploy/point-robinson.yaml
+++ b/InferenceSystem/deploy/point-robinson.yaml
@@ -36,6 +36,10 @@ spec:
               secretKeyRef:
                 name: inference-system
                 key: INFERENCESYSTEM_APPINSIGHTS_CONNECTION_STRING
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MKL_NUM_THREADS
+            value: "1"
         volumeMounts:
           - name: config-volume
             mountPath: /config


### PR DESCRIPTION
Huge improvement in the benchmark script provided in issue #368 just requires setting environment variables to run single-threaded:
```
root@benchmark-pod-7c445dfc74-ttqpl:/usr/src/app# python3 /benchmark.py
NumPy benchmark:
Matrix multiply (2000x2000) took 1.7688 seconds

PyTorch CPU benchmark:
Matrix multiply (2000x2000) on CPU took 14.4335 seconds

No GPU detected (torch.cuda.is_available() == False)

root@benchmark-pod-7c445dfc74-ttqpl:/usr/src/app# export MKL_NUM_THREADS=1

root@benchmark-pod-7c445dfc74-ttqpl:/usr/src/app# python3 /benchmark.py
NumPy benchmark:
Matrix multiply (2000x2000) took 1.5956 seconds

PyTorch CPU benchmark:
Matrix multiply (2000x2000) on CPU took 0.5927 seconds

No GPU detected (torch.cuda.is_available() == False)
root@benchmark-pod-7c445dfc74-ttqpl:/usr/src/app#
```

This fix is currently deployed to andrews-bay and point-robinson (north-sjc is stopped) to verify behavior of the actual inference containers.  Looks good so far.

Fixes #368 