### PR TITLE
Optimize FastAIModel for reduced peak memory during inference 

### DIFF
--- a/InferenceSystem/src/model/fastai_inference.py
+++ b/InferenceSystem/src/model/fastai_inference.py
@@ -199,7 +199,7 @@ class FastAIModel():
             del test
             del testdb
             gc.collect()
-            if torch.cuda.is_available():
+            if self.use_gpu and torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
             # Aggregating predictions


### PR DESCRIPTION
Implements memory and cleanup optimizations for FastAIModel inference.

## Changes Made

- **Add batch_size and use_gpu parameters**: Constructor now accepts `batch_size` (default 32) and `use_gpu` (default False) parameters
- **Device placement in init**: Model is moved to GPU/CPU once during initialization instead of on every predict() call
- **try/finally cleanup**: Ensures temp WAV files are cleaned up even on exceptions
- **Cleanup logging**: Temp directory cleanup failures are now logged instead of silently ignored
- **Explicit memory release**: Deletes large fastai objects (`test`, `testdb`) after processing and calls `gc.collect()` + `torch.cuda.empty_cache()`
- **Other fixes**: `pd.concat()` instead of deprecated `append()`, fixed typos

## Note on Batched Inference

The original goal of using `get_preds()` for batched inference couldn't be implemented because FastAI 1.x's DataLoader ordering doesn't match `test_data_folder.ls()` ordering, causing path-prediction alignment issues. The `batch_size` parameter is used for DataLoader creation but predictions are made per-item using fastai's `predict()` method (which handles `model.eval()` and gradient context internally) to ensure correct alignment.

## Testing

Validate that outputs (submission dataframe, local_predictions, local_confidences, global_prediction, global_confidence) are unchanged compared to previous behavior for a sample WAV file.