### PR TITLE
Add category to moderator notification emails

### DIFF
--- a/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
@@ -10,6 +10,8 @@ namespace NotificationSystem.Tests.Unit
 {
     public class EmailTemplateTests
     {
+        #region Subscriber Tests
+
         /// <summary>
         /// Tests that GetSubscriberEmailBody generates correct map URIs for various locations
         /// by verifying the generated HTML contains the expected image URLs.
@@ -60,7 +62,7 @@ namespace NotificationSystem.Tests.Unit
             string expectedMapUrl = $"https://orcanotificationstorage.blob.core.windows.net/images/{expectedFileName}";
 
             // Act - with OrcasiteHelper as in production
-            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, mockOrcasiteHelper.Object);
+            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, "Southern Resident Killer Whale", mockOrcasiteHelper.Object);
 
             // Assert
             Assert.Contains(expectedMapUrl, emailBody);
@@ -96,7 +98,7 @@ namespace NotificationSystem.Tests.Unit
                 .Returns("north-sjc");
 
             // Act - with OrcasiteHelper as in production
-            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, mockOrcasiteHelper.Object);
+            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, "Southern Resident Killer Whale", mockOrcasiteHelper.Object);
 
             // Assert - the URI should use "north-sjc" from OrcasiteHelper
             Assert.Contains("north-sjc.jpg", emailBody);
@@ -127,7 +129,7 @@ namespace NotificationSystem.Tests.Unit
             });
 
             // Act - without OrcasiteHelper, it falls back to simple transformation
-            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, null);
+            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, "Southern Resident Killer Whale", null);
 
             // Assert - should use simple transformation
             Assert.Contains("sunset-bay.jpg", emailBody);
@@ -157,7 +159,7 @@ namespace NotificationSystem.Tests.Unit
             });
 
             // Act - without OrcasiteHelper, it falls back to simple transformation
-            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, null);
+            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, "Southern Resident Killer Whale", null);
 
             // Assert
             Assert.Contains("Southern Resident Killer Whale Detected", emailBody);
@@ -203,7 +205,7 @@ namespace NotificationSystem.Tests.Unit
                 });
             
             // Act
-            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, mockOrcasiteHelper.Object);
+            string emailBody = EmailTemplate.GetSubscriberEmailBody(message, "Southern Resident Killer Whale", mockOrcasiteHelper.Object);
 
             // Assert - should use "north-sjc" from OrcasiteHelper, not "north-san-juan-channel"
             Assert.Contains("north-sjc.jpg", emailBody);
@@ -234,10 +236,10 @@ namespace NotificationSystem.Tests.Unit
 
             // Act
             string location = EmailTemplate.GetLocation(message);
-            string subject = EmailTemplate.GetSubscriberEmailSubject(location);
+            string subject = EmailTemplate.GetSubscriberEmailSubject("Southern Resident Killer Whale", location);
 
             // Assert
-            Assert.Equal("Notification: Orca detected at location Sunset Bay", subject);
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Sunset Bay", subject);
         }
 
         /// <summary>
@@ -263,11 +265,212 @@ namespace NotificationSystem.Tests.Unit
 
             // Act
             string location = EmailTemplate.GetLocation(message);
-            string subject = EmailTemplate.GetSubscriberEmailSubject(location);
+            string subject = EmailTemplate.GetSubscriberEmailSubject("Southern Resident Killer Whale", location);
 
             // Assert
-            Assert.Equal("Notification: Orca detected at location Unknown", subject);
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Unknown", subject);
         }
+
+        /// <summary>
+        /// Tests that GetSubscriberEmailSubject handles null location with "Unknown".
+        /// </summary>
+        [Fact]
+        public void GetSubscriberEmailSubject_HandlesNullLocation()
+        {
+            // Arrange
+            string category = "Southern Resident Killer Whale";
+            string location = null;
+
+            // Act
+            string subject = EmailTemplate.GetSubscriberEmailSubject(category, location);
+
+            // Assert
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Unknown", subject);
+        }
+        
+        #endregion
+
+        #region Moderator Tests
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody contains all required sections.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailBody_ContainsAllRequiredSections()
+        {
+            // Arrange
+            var testTimestamp = new DateTime(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            Assert.Contains("Southern Resident Killer Whale Call Candidate", emailBody);
+            Assert.Contains(category, emailBody);
+            Assert.Contains(location, emailBody);
+            Assert.Contains("Orca Moderation Portal", emailBody);
+            Assert.Contains("https://aifororcas.azurewebsites.net/", emailBody);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody handles null timestamp gracefully.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailBody_HandlesNullTimestamp()
+        {
+            // Arrange
+            DateTime? testTimestamp = null;
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            Assert.Contains("unknown time", emailBody);
+            Assert.Contains("Southern Resident Killer Whale Call Candidate", emailBody);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody formats timestamp to PDT correctly.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailBody_FormatsTimestampToPDT()
+        {
+            // Arrange
+            var testTimestamp = new DateTime(2025, 1, 15, 18, 30, 0, DateTimeKind.Utc); // 6:30 PM UTC
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            // UTC 18:30 converts to PST 10:30 (UTC-8 during standard time)
+            Assert.Contains("PDT", emailBody);
+            // Verify the date is present
+            Assert.Contains("1/15/2025", emailBody);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody includes proper HTML structure.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailBody_IncludesValidHtmlStructure()
+        {
+            // Arrange
+            var testTimestamp = new DateTime(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            Assert.StartsWith("<html>", emailBody);
+            Assert.Contains("<style>", emailBody);
+            Assert.Contains("</style>", emailBody);
+            Assert.Contains("<body>", emailBody);
+            Assert.Contains("</body>", emailBody);
+            Assert.EndsWith("</html>", emailBody);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailSubject generates correct subject line with category and location.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailSubject_IncludesCategoryAndLocation()
+        {
+            // Arrange
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
+
+            // Assert
+            Assert.Equal("Southern Resident Killer Whale Candidate at location Sunset Bay", subject);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailSubject handles empty location with "Unknown".
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailSubject_HandlesEmptyLocation()
+        {
+            // Arrange
+            string category = "Southern Resident Killer Whale";
+            string location = "";
+
+            // Act
+            string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
+
+            // Assert
+            Assert.Equal("Southern Resident Killer Whale Candidate at location Unknown", subject);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailSubject handles null location with "Unknown".
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailSubject_HandlesNullLocation()
+        {
+            // Arrange
+            string category = "Southern Resident Killer Whale";
+            string location = null;
+
+            // Act
+            string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
+
+            // Assert
+            Assert.Equal("Southern Resident Killer Whale Candidate at location Unknown", subject);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody works with different category types.
+        /// </summary>
+        [Theory]
+        [InlineData("Southern Resident Killer Whale")]
+        [InlineData("Humpback Whale")]
+        [InlineData("Other")]
+        public void GetModeratorEmailBody_WorksWithDifferentCategories(string category)
+        {
+            // Arrange
+            var testTimestamp = new DateTime(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            Assert.Contains(category, emailBody);
+            Assert.Contains($"{category} Call Candidate", emailBody);
+            Assert.Contains(location, emailBody);
+        }
+
+        /// <summary>
+        /// Tests that GetModeratorEmailBody includes the portal link button.
+        /// </summary>
+        [Fact]
+        public void GetModeratorEmailBody_IncludesPortalLinkButton()
+        {
+            // Arrange
+            var testTimestamp = new DateTime(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            string category = "Southern Resident Killer Whale";
+            string location = "Sunset Bay";
+
+            // Act
+            string emailBody = EmailTemplate.GetModeratorEmailBody(testTimestamp, category, location);
+
+            // Assert
+            Assert.Contains("Go to portal", emailBody);
+            Assert.Contains("button-link", emailBody);
+            Assert.Contains("https://aifororcas.azurewebsites.net/", emailBody);
+        }
+
+        #endregion
 
         /// <summary>
         /// Tests that GetLocation handles null location.
@@ -288,6 +491,28 @@ namespace NotificationSystem.Tests.Unit
 
             // Assert
             Assert.Null(location);
+        }
+
+        /// <summary>
+        /// Tests that GetCategory correctly identifies different whale categories from comments.
+        /// </summary>
+        [Theory]
+        [InlineData("AI: resident", "Southern Resident Killer Whale")]
+        [InlineData("AI: resident and vessel", "Southern Resident Killer Whale")]
+        [InlineData("AI: transient", "Transient Killer Whale")]
+        [InlineData("AI: transient and vessel", "Transient Killer Whale")]
+        [InlineData("AI: humpback", "Humpback")]
+        [InlineData("AI: humpback and vessel", "Humpback")]
+        [InlineData("Other", "Southern Resident Killer Whale")] // Default case
+        [InlineData("", "Southern Resident Killer Whale")] // Empty string default
+        [InlineData(null, "Southern Resident Killer Whale")] // Null default
+        public void GetCategory_IdentifiesCorrectCategory(string? comments, string expectedCategory)
+        {
+            // Act
+            string category = EmailTemplate.GetCategory(comments);
+
+            // Assert
+            Assert.Equal(expectedCategory, category);
         }
     }
 }

--- a/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
@@ -334,10 +334,10 @@ namespace NotificationSystem.Tests.Unit
         }
 
         /// <summary>
-        /// Tests that GetModeratorEmailBody formats timestamp to PDT correctly.
+        /// Tests that GetModeratorEmailBody formats timestamp to Pacific correctly.
         /// </summary>
         [Fact]
-        public void GetModeratorEmailBody_FormatsTimestampToPDT()
+        public void GetModeratorEmailBody_FormatsTimestampToPacific()
         {
             // Arrange
             var testTimestamp = new DateTime(2025, 1, 15, 18, 30, 0, DateTimeKind.Utc); // 6:30 PM UTC
@@ -349,7 +349,7 @@ namespace NotificationSystem.Tests.Unit
 
             // Assert
             // UTC 18:30 converts to PST 10:30 (UTC-8 during standard time)
-            Assert.Contains("PDT", emailBody);
+            Assert.Contains("Pacific", emailBody);
             // Verify the date is present
             Assert.Contains("1/15/2025", emailBody);
         }

--- a/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
@@ -23,7 +23,7 @@ namespace NotificationSystem.Tests.Unit
         [InlineData("North San Juan Channel", "north-sjc.jpg")]
         [InlineData("Point Robinson", "point-robinson.jpg")]
         [InlineData("Bush Point", "bush-point.jpg")]
-        [InlineData("Haro Strait", "haro-strait.jpg")]
+        [InlineData("Andrews Bay", "andrews-bay.jpg")]
         [InlineData("Port Townsend", "port-townsend.jpg")]
         [InlineData("Orcasound Lab", "orcasound-lab.jpg")]
         public void GetSubscriberEmailBody_GeneratesCorrectMapUri_ForLocationName(string locationName, string expectedFileName)

--- a/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace NotificationSystem
 {
@@ -57,7 +56,8 @@ namespace NotificationSystem
                     newDocumentCreated = true;
                     documentTimeStamp = document.GetProperty("timestamp").GetDateTime();
                     location = document.GetProperty("location").GetProperty("name").GetString();
-                    comments = document.GetProperty("comments").GetString();
+                    document.TryGetProperty("comments", out var commentsElement);
+                    comments = commentsElement.ValueKind != JsonValueKind.Null ? commentsElement.GetString() : null;
                 }
             }
 

--- a/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
@@ -56,8 +56,10 @@ namespace NotificationSystem
                     newDocumentCreated = true;
                     documentTimeStamp = document.GetProperty("timestamp").GetDateTime();
                     location = document.GetProperty("location").GetProperty("name").GetString();
-                    document.TryGetProperty("comments", out var commentsElement);
-                    comments = commentsElement.ValueKind != JsonValueKind.Null ? commentsElement.GetString() : null;
+                    comments = document.TryGetProperty("comments", out var commentsElement) &&
+                        commentsElement.ValueKind == JsonValueKind.String
+                        ? commentsElement.GetString()
+                        : null;
                 }
             }
 

--- a/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendModeratorEmail.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace NotificationSystem
 {
@@ -45,6 +46,7 @@ namespace NotificationSystem
             var newDocumentCreated = false;
             DateTime? documentTimeStamp = null;
             string location = null;
+            string comments = null;
 
             foreach (var document in input)
             {
@@ -55,6 +57,7 @@ namespace NotificationSystem
                     newDocumentCreated = true;
                     documentTimeStamp = document.GetProperty("timestamp").GetDateTime();
                     location = document.GetProperty("location").GetProperty("name").GetString();
+                    comments = document.GetProperty("comments").GetString();
                 }
             }
 
@@ -64,7 +67,8 @@ namespace NotificationSystem
                 return;
             }
 
-            string body = EmailTemplate.GetModeratorEmailBody(documentTimeStamp, location);
+            string category = EmailTemplate.GetCategory(comments);
+            string body = EmailTemplate.GetModeratorEmailBody(documentTimeStamp, category, location);
 
             var timeConstraint = TimeLimiter.GetFromMaxCountByInterval(SendRate, TimeSpan.FromSeconds(1));
             var aws = new AmazonSimpleEmailServiceClient(RegionEndpoint.USWest2);
@@ -72,7 +76,7 @@ namespace NotificationSystem
             foreach (var emailEntity in await EmailHelpers.GetEmailEntitiesAsync<ModeratorEmailEntity>(tableClient, "Moderator"))
             {
                 await timeConstraint;
-                string emailSubject = $"OrcaHello Candidate at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
+                string emailSubject = EmailTemplate.GetModeratorEmailSubject(category, location);
                 var email = EmailHelpers.CreateEmail(Environment.GetEnvironmentVariable("SenderEmail"),
                     emailEntity.Email, emailSubject, body);
                 await aws.SendEmailAsync(email);

--- a/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
@@ -99,8 +99,6 @@ namespace NotificationSystem
 
         private string CreateBody(JObject messageJson, string category)
         {
-            var bodyBuilder = new StringBuilder($"<h1>Confirmed {category} detections:</h1>\n<ul>");
-
             return EmailTemplate.GetSubscriberEmailBody(messageJson, category, _orcasiteHelper);
         }
     }

--- a/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
+++ b/NotificationSystem/NotificationSystem/SendSubscriberEmail.cs
@@ -64,8 +64,9 @@ namespace NotificationSystem
             foreach (var message in messages)
             {
                 string location = EmailTemplate.GetLocation(message);
-                string emailSubject = EmailTemplate.GetSubscriberEmailSubject(location);
-                string body = CreateBody(message);
+                string category = "Southern Resident Killer Whale";
+                string emailSubject = EmailTemplate.GetSubscriberEmailSubject(category, location);
+                string body = CreateBody(message, category);
                 foreach (var emailEntity in await EmailHelpers.GetEmailEntitiesAsync<SubscriberEmailEntity>(tableClient, "Subscriber"))
                 {
                     await timeConstraint;
@@ -96,11 +97,11 @@ namespace NotificationSystem
             return messagesJson;
         }
 
-        private string CreateBody(JObject messageJson)
+        private string CreateBody(JObject messageJson, string category)
         {
-            var bodyBuilder = new StringBuilder("<h1>Confirmed SRKW detections:</h1>\n<ul>");
+            var bodyBuilder = new StringBuilder($"<h1>Confirmed {category} detections:</h1>\n<ul>");
 
-            return EmailTemplate.GetSubscriberEmailBody(messageJson, _orcasiteHelper);
+            return EmailTemplate.GetSubscriberEmailBody(messageJson, category, _orcasiteHelper);
         }
     }
 }

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace NotificationSystem.Template
 {
-    // TODO: we should move all html out of code and maybe use a preset email template for better design. 
+    // TODO: we should move all html out of code and maybe use a preset email template for better design.
     public static class EmailTemplate
     {
         public static string GetModeratorEmailBody(DateTime? timestamp, string category, string location)
@@ -58,7 +58,7 @@ namespace NotificationSystem.Template
 
         private static string GetSubscriberEmailHtml(JObject message, string category, OrcasiteHelper orcasiteHelper)
         {
-            string timeString = GetPDTTimestring((DateTime?) message["timestamp"]);
+            string timeString = GetPacificTimestring((DateTime?) message["timestamp"]);
 
             return $@"
                 <body>
@@ -67,7 +67,7 @@ namespace NotificationSystem.Template
                 {category} Detected
                 </h1>
                 <p>
-                Dear subscriber, a {category} was most recently detected at around {timeString} PDT. 
+                Dear subscriber, a {category} was most recently detected at around {timeString} Pacific.
                 </p>
                 <p>
                 Please be mindful of their presence when travelling in the areas below.
@@ -93,7 +93,7 @@ namespace NotificationSystem.Template
 
         private static string GetDetectedSectionHtml(JObject message, OrcasiteHelper orcasiteHelper)
         {
-            string timeString = GetPDTTimestring((DateTime?)message["timestamp"]);
+            string timeString = GetPacificTimestring((DateTime?)message["timestamp"]);
 
             return $@"
                   <tr>
@@ -121,19 +121,19 @@ namespace NotificationSystem.Template
         {
             // Try to get the slug from OrcasiteHelper first
             string slug = orcasiteHelper?.GetSlugByLocationName(locationName);
-            
+
             if (string.IsNullOrEmpty(slug))
             {
                 // Fall back to converting location name to lowercase and replacing spaces with hyphens
                 slug = locationName.ToLower().Replace(" ", "-");
             }
-            
+
             return $"https://orcanotificationstorage.blob.core.windows.net/images/{slug}.jpg";
         }
 
         private static string GetModeratorEmailHtml(DateTime? timestamp, string category, string location)
         {
-            string timeString = GetPDTTimestring(timestamp);
+            string timeString = GetPacificTimestring(timestamp);
 
             return $@"
                 <body>
@@ -142,7 +142,7 @@ namespace NotificationSystem.Template
                 {category} Call Candidate
                 </h1>
                 <p>
-                Dear moderator, a potential {category} call was detected on {timeString} PDT at {location} location. 
+                Dear moderator, a potential {category} call was detected on {timeString} Pacific at {location} location.
                 </p>
                 <p>
                 This is a request for your moderation to confirm whether the sound was produced by a {category} on the portal below.
@@ -152,7 +152,7 @@ namespace NotificationSystem.Template
                 Orca Moderation Portal
                 </h2>
                 <p>
-                Please click the link below to move to the portal. 
+                Please click the link below to move to the portal.
                 </p>
                 <a href='https://aifororcas.azurewebsites.net/' class='button-link'>
                 Go to portal
@@ -209,7 +209,7 @@ namespace NotificationSystem.Template
             ";
         }
 
-        private static string GetPDTTimestring(DateTime? timestamp)
+        private static string GetPacificTimestring(DateTime? timestamp)
         {
             var pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
             return timestamp != null ? (TimeZoneInfo.ConvertTimeFromUtc(timestamp.Value, pacificTimeZone).ToShortDateString() + " " + TimeZoneInfo.ConvertTimeFromUtc(timestamp.Value, pacificTimeZone).ToLongTimeString()) : "unknown time";

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -35,7 +35,6 @@ namespace NotificationSystem.Template
         public static string GetLocation(JObject message)
         {
             // Extract location from first message
-            string location = null;
             try
             {
                 return message["location"]?["name"]?.ToString();

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -9,14 +9,27 @@ namespace NotificationSystem.Template
     // TODO: we should move all html out of code and maybe use a preset email template for better design. 
     public static class EmailTemplate
     {
-        public static string GetModeratorEmailBody(DateTime? timestamp, string location)
+        public static string GetModeratorEmailBody(DateTime? timestamp, string category, string location)
         {
-            return $"<html><head><style>{GetCSS()}</style></head><body>{GetModeratorEmailHtml(timestamp, location)}</body></html>";
+            return $"<html><head><style>{GetCSS()}</style></head><body>{GetModeratorEmailHtml(timestamp, category, location)}</body></html>";
         }
 
-        public static string GetSubscriberEmailBody(JObject message, OrcasiteHelper orcasiteHelper = null)
+        public static string GetSubscriberEmailBody(JObject message, string category, OrcasiteHelper orcasiteHelper = null)
         {
-            return $"<html><head><style>{GetCSS()}</style></head><body>{GetSubscriberEmailHtml(message, orcasiteHelper)}</body></html>";
+            return $"<html><head><style>{GetCSS()}</style></head><body>{GetSubscriberEmailHtml(message, category, orcasiteHelper)}</body></html>";
+        }
+
+        public static string GetCategory(string? comments)
+        {
+            if (comments?.Contains("transient") == true)
+            {
+                return "Transient Killer Whale";
+            }
+            if (comments?.Contains("humpback") == true)
+            {
+                return "Humpback";
+            }
+            return "Southern Resident Killer Whale";
         }
 
         public static string GetLocation(JObject message)
@@ -33,12 +46,17 @@ namespace NotificationSystem.Template
             }
         }
 
-        public static string GetSubscriberEmailSubject(string location)
+        public static string GetModeratorEmailSubject(string category, string location)
         {
-            return $"Notification: Orca detected at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
+            return $"{category} Candidate at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
         }
 
-        private static string GetSubscriberEmailHtml(JObject message, OrcasiteHelper orcasiteHelper)
+        public static string GetSubscriberEmailSubject(string category, string location)
+        {
+            return $"Notification: {category} detected at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
+        }
+
+        private static string GetSubscriberEmailHtml(JObject message, string category, OrcasiteHelper orcasiteHelper)
         {
             string timeString = GetPDTTimestring((DateTime?) message["timestamp"]);
 
@@ -46,10 +64,10 @@ namespace NotificationSystem.Template
                 <body>
                 <div class='card'>
                 <h1>
-                Southern Resident Killer Whale Detected
+                {category} Detected
                 </h1>
                 <p>
-                Dear subscriber, a Southern Resident Killer Whale was most recently detected at around {timeString} PDT. 
+                Dear subscriber, a {category} was most recently detected at around {timeString} PDT. 
                 </p>
                 <p>
                 Please be mindful of their presence when travelling in the areas below.
@@ -113,7 +131,7 @@ namespace NotificationSystem.Template
             return $"https://orcanotificationstorage.blob.core.windows.net/images/{slug}.jpg";
         }
 
-        private static string GetModeratorEmailHtml(DateTime? timestamp, string location)
+        private static string GetModeratorEmailHtml(DateTime? timestamp, string category, string location)
         {
             string timeString = GetPDTTimestring(timestamp);
 
@@ -121,13 +139,13 @@ namespace NotificationSystem.Template
                 <body>
                 <div class='card'>
                 <h1>
-                Orca Call Candidate
+                {category} Call Candidate
                 </h1>
                 <p>
-                Dear moderator, a potential Southern Resident Killer Whale call was detected on {timeString} PDT at {location} location. 
+                Dear moderator, a potential {category} call was detected on {timeString} PDT at {location} location. 
                 </p>
                 <p>
-                This is a request for your moderation to confirm whether the sound was produced by Southern Resident Killer Whale on the portal below.
+                This is a request for your moderation to confirm whether the sound was produced by a {category} on the portal below.
                 </p>
                 <hr/>
                 <h2>


### PR DESCRIPTION
* If the "comments" field is populated in unreviewed detections, use it to get a category to use in the emails. 
* Instead of just saying "Orca" for SRKW in one place, use "Southern Resident Killer Whale" for consistency.
* Instead of saying "PDT" when it is actually PST for half the year, just say "Pacific"
* Add unit tests for moderator email methods