### PR TITLE
Update inference image to what is actually deployed

### DIFF
--- a/InferenceSystem/deploy/andrews-bay.yaml
+++ b/InferenceSystem/deploy/andrews-bay.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/bush-point.yaml
+++ b/InferenceSystem/deploy/bush-point.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/mast-center.yaml
+++ b/InferenceSystem/deploy/mast-center.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/north-sjc.yaml
+++ b/InferenceSystem/deploy/north-sjc.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/orcasound-lab.yaml
+++ b/InferenceSystem/deploy/orcasound-lab.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/point-robinson.yaml
+++ b/InferenceSystem/deploy/point-robinson.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/port-townsend.yaml
+++ b/InferenceSystem/deploy/port-townsend.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:

--- a/InferenceSystem/deploy/sunset-bay.yaml
+++ b/InferenceSystem/deploy/sunset-bay.yaml
@@ -24,14 +24,14 @@ spec:
         kubernetes.azure.com/agentpool: f4sv2pool
       containers:
         - name: inference-system
-          image: orcaconservancycr.azurecr.io/live-inference-system:03-20-2026.v2.1.0
+          image: orcaconservancycr.azurecr.io/live-inference-system:04-28-2026.v2.1.1
           resources:
             requests:
-              cpu: "1"
-              memory: "1600Mi"
+              cpu: "200m"
+              memory: "1200Mi"
             limits:
-              cpu: "1"
-              memory: "2500Mi"
+              cpu: "500m"
+              memory: "1800Mi"
           env:
             - name: AZURE_COSMOSDB_PRIMARY_KEY
               valueFrom:


### PR DESCRIPTION
Lower resource requests/limits based on actual usage after Akash's fixes, so more pods can fit on a node.

Snapshot of actual usage from `kubectl top pod --all-namespaces`:
```
NAMESPACE       NAME                                           CPU(cores)   MEMORY(bytes)
andrews-bay     inference-system-6d9d77fcd9-l7snk              159m         1149Mi
bush-point      inference-system-7f68595dbd-f7hx9              131m         782Mi
mast-center     inference-system-79d8f85fb6-g9zlv              148m         746Mi
north-sjc       inference-system-79d8f85fb6-skg6m              150m         778Mi
orcasound-lab   inference-system-79d8f85fb6-bkj5t              177m         783Mi
port-townsend   inference-system-75bf5d858d-csd9m              127m         785Mi
sunset-bay      inference-system-79d8f85fb6-xczvh              175m         787Mi
```