### PR TITLE
Tweak wording in email notifications

### DIFF
--- a/NotificationSystem/NotificationSystem.Tests.Integration/SendModeratorEmailIntegrationTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Integration/SendModeratorEmailIntegrationTests.cs
@@ -31,7 +31,7 @@ namespace NotificationSystem.Tests.Integration
                     {
                         reviewed = false,
                         timestamp = DateTime.UtcNow,
-                        location = new { name = "Mast Center" }
+                        location = new { name = "MaST Center" }
                     })
                 };
                 var recipients = new List<ModeratorEmailEntity> { new("moderator@example.com") };
@@ -42,7 +42,50 @@ namespace NotificationSystem.Tests.Integration
                     x => x.SendEmailAsync(It.Is<SendEmailRequest>(request =>
                         request.Source == "sender@example.com" &&
                         request.Destination.ToAddresses.Contains("moderator@example.com") &&
-                        request.Message.Subject.Data.Contains("Mast Center"))),
+                        request.Message.Subject.Data.Contains("MaST Center"))),
+                    Times.Once);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SenderEmail", previousSenderEmail);
+            }
+        }
+
+        [Fact]
+        public async Task ProcessDocumentsAsync_SendsEmail_ForUnreviewedDetectionWithCategory()
+        {
+            string? previousSenderEmail = Environment.GetEnvironmentVariable("SenderEmail");
+            Environment.SetEnvironmentVariable("SenderEmail", "sender@example.com");
+
+            try
+            {
+                var emailServiceMock = new Mock<IEmailService>();
+                emailServiceMock.Setup(x => x.SendEmailAsync(It.IsAny<SendEmailRequest>()))
+                    .Returns(Task.CompletedTask);
+
+                var loggerMock = new Mock<ILogger<SendModeratorEmail>>();
+                var function = new SendModeratorEmail(loggerMock.Object, emailServiceMock.Object);
+
+                var input = new List<JsonElement>
+                {
+                    JsonSerializer.SerializeToElement(new
+                    {
+                        reviewed = false,
+                        timestamp = DateTime.UtcNow,
+                        location = new { name = "MaST Center" },
+                        comments = "AI: humpback and vessel"
+                    })
+                };
+                var recipients = new List<ModeratorEmailEntity> { new("moderator@example.com") };
+
+                await function.ProcessDocumentsAsync(input, recipients);
+
+                emailServiceMock.Verify(
+                    x => x.SendEmailAsync(It.Is<SendEmailRequest>(request =>
+                        request.Source == "sender@example.com" &&
+                        request.Destination.ToAddresses.Contains("moderator@example.com") &&
+                        request.Message.Subject.Data.Contains("MaST Center") &&
+                        request.Message.Body.Html.Data.Contains("humpback"))),
                     Times.Once);
             }
             finally

--- a/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
+++ b/NotificationSystem/NotificationSystem.Tests.Unit/EmailTemplateTests.cs
@@ -239,7 +239,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetSubscriberEmailSubject("Southern Resident Killer Whale", location);
 
             // Assert
-            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Sunset Bay", subject);
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at Sunset Bay", subject);
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetSubscriberEmailSubject("Southern Resident Killer Whale", location);
 
             // Assert
-            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Unknown", subject);
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at Unknown", subject);
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetSubscriberEmailSubject(category, location);
 
             // Assert
-            Assert.Equal("Notification: Southern Resident Killer Whale detected at location Unknown", subject);
+            Assert.Equal("Notification: Southern Resident Killer Whale detected at Unknown", subject);
         }
         
         #endregion
@@ -391,7 +391,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
 
             // Assert
-            Assert.Equal("Southern Resident Killer Whale Candidate at location Sunset Bay", subject);
+            Assert.Equal("Southern Resident Killer Whale Candidate at Sunset Bay", subject);
         }
 
         /// <summary>
@@ -408,7 +408,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
 
             // Assert
-            Assert.Equal("Southern Resident Killer Whale Candidate at location Unknown", subject);
+            Assert.Equal("Southern Resident Killer Whale Candidate at Unknown", subject);
         }
 
         /// <summary>
@@ -425,7 +425,7 @@ namespace NotificationSystem.Tests.Unit
             string subject = EmailTemplate.GetModeratorEmailSubject(category, location);
 
             // Assert
-            Assert.Equal("Southern Resident Killer Whale Candidate at location Unknown", subject);
+            Assert.Equal("Southern Resident Killer Whale Candidate at Unknown", subject);
         }
 
         /// <summary>
@@ -433,7 +433,8 @@ namespace NotificationSystem.Tests.Unit
         /// </summary>
         [Theory]
         [InlineData("Southern Resident Killer Whale")]
-        [InlineData("Humpback Whale")]
+        [InlineData("Transient Killer Whale")]
+        [InlineData("Humpback")]
         [InlineData("Other")]
         public void GetModeratorEmailBody_WorksWithDifferentCategories(string category)
         {

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -66,7 +66,7 @@ namespace NotificationSystem.Template
                 {category} Detected
                 </h1>
                 <p>
-                Dear subscriber, a {category} was most recently detected at around {timeString} Pacific.
+                Dear subscriber, a {category.ToLower()} was most recently detected at around {timeString} Pacific.
                 </p>
                 <p>
                 Please be mindful of their presence when travelling in the areas below.
@@ -141,10 +141,10 @@ namespace NotificationSystem.Template
                 {category} Call Candidate
                 </h1>
                 <p>
-                Dear moderator, a potential {category} call was detected on {timeString} Pacific at {location}.
+                Dear moderator, a potential {category.ToLower()} call was detected on {timeString} Pacific at {location}.
                 </p>
                 <p>
-                This is a request for your moderation to confirm whether the sound was produced by a {category} on the portal below.
+                This is a request for your moderation to confirm whether the sound was produced by a {category.ToLower()} on the portal below.
                 </p>
                 <hr/>
                 <h2>

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -141,7 +141,7 @@ namespace NotificationSystem.Template
                 {category} Call Candidate
                 </h1>
                 <p>
-                Dear moderator, a potential {category.ToLower()} call was detected on {timeString} Pacific at {location}.
+                Dear moderator, a potential {category.ToLower()} call was flagged on {timeString} Pacific at {location}.
                 </p>
                 <p>
                 This is a request for your moderation to confirm whether the sound was produced by a {category.ToLower()} on the portal below.

--- a/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
+++ b/NotificationSystem/NotificationSystem/Template/EmailTemplate.cs
@@ -47,12 +47,12 @@ namespace NotificationSystem.Template
 
         public static string GetModeratorEmailSubject(string category, string location)
         {
-            return $"{category} Candidate at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
+            return $"{category} Candidate at {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
         }
 
         public static string GetSubscriberEmailSubject(string category, string location)
         {
-            return $"Notification: {category} detected at location {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
+            return $"Notification: {category} detected at {(string.IsNullOrEmpty(location) ? "Unknown" : location)}";
         }
 
         private static string GetSubscriberEmailHtml(JObject message, string category, OrcasiteHelper orcasiteHelper)
@@ -141,7 +141,7 @@ namespace NotificationSystem.Template
                 {category} Call Candidate
                 </h1>
                 <p>
-                Dear moderator, a potential {category} call was detected on {timeString} Pacific at {location} location.
+                Dear moderator, a potential {category} call was detected on {timeString} Pacific at {location}.
                 </p>
                 <p>
                 This is a request for your moderation to confirm whether the sound was produced by a {category} on the portal below.


### PR DESCRIPTION
 * Remove redundant word "location"
 * Lowercase category when it appears in the middle of a sentence
 * Add another test

Example of previous wording:
> Dear moderator, a potential Humpback call was detected on 6/23/2026 5:38:49 AM Pacific at Andrews Bay location. 
This is a request for your moderation to confirm whether the sound was produced by a Humpback on the portal below. 

Now:
> Dear moderator, a potential humpback call was detected on 6/23/2026 5:38:49 AM Pacific at Andrews Bay. 
This is a request for your moderation to confirm whether the sound was produced by a humpback on the portal below. 

 