### PR TITLE
Display read-only comments and tags to unauthenticated users

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -154,7 +154,12 @@
                         </div>
                         <div class="row">
                             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                                <p><i class="fas fa-comment pr-2"></i>@Detection.Comments</p>
+                                <div class="d-flex">
+                                    <i class="fas fa-comment pr-2"></i>
+                                    <div style="white-space: pre-wrap; margin-top: -5px;">
+                                        @Detection.Comments
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </NotAuthorized>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -146,17 +146,17 @@
                                     <p><i class="fas fa-fish pr-2"></i>@WasFound</p>
                                 </div>
                             </div>
-                            <div class="row">
-                                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                                    <p><i class="fas fa-tags pr-2"></i>@Detection.Tags</p>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                                    <p><i class="fas fa-comment pr-2"></i>@Detection.Comments</p>
-                                </div>
-                            </div>
                         }
+                        <div class="row">
+                            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                                <p><i class="fas fa-tags pr-2"></i>@Detection.Tags</p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                                <p><i class="fas fa-comment pr-2"></i>@Detection.Comments</p>
+                            </div>
+                        </div>
                     </NotAuthorized>
                 </AuthorizeView>
             </div>


### PR DESCRIPTION
PODS-AI fills in tags and comments, so they can be present before a moderator has reviewed.
This PR displays those (read-only) to unauthenticated users.

It's easiest to review using "Hide whitespace".
The format change for comments when viewed authenticated is to preserve newlines.