### PR TITLE
Fix Details links opened in a new tab showing the candidates page

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -18,8 +18,11 @@
                  aria-labelledby="dropdownMenuLink">
                 <a class="dropdown-item"
                    href="@LinkUrl"
+                   data-modal-target="#@ModalSpectrogramPanelId"
+                   data-detection-id="@Detection.Id"
+                   data-audio-uri="@Detection.AudioUri"
                    data-regions="@RegionsJson"
-                   onclick="return OpenSpectrogramModal(event, '#@ModalSpectrogramPanelId', '@Detection.Id', '@Detection.AudioUri', this.dataset.regions)">View Spectrogram Details</a>
+                   onclick="return OpenSpectrogramModal(event, this)">View Spectrogram Details</a>
                 <a class="dropdown-item"
                    href="#@ModalMapPanelId"
                    data-toggle="modal"
@@ -185,8 +188,11 @@
         <a href="@LinkUrl"
            role="button"
            class="btn btn-outline-success"
+           data-modal-target="#@ModalSpectrogramPanelId"
+           data-detection-id="@Detection.Id"
+           data-audio-uri="@Detection.AudioUri"
            data-regions="@RegionsJson"
-           onclick="return OpenSpectrogramModal(event, '#@ModalSpectrogramPanelId', '@Detection.Id', '@Detection.AudioUri', this.dataset.regions)"><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
+           onclick="return OpenSpectrogramModal(event, this)"><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
 
         <a href="#@ModalMapPanelId"
            role="button"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -18,10 +18,8 @@
                  aria-labelledby="dropdownMenuLink">
                 <a class="dropdown-item"
                    href="@LinkUrl"
-                   data-toggle="modal"
-                   data-target="#@ModalSpectrogramPanelId"
-                   @onclick="(()=>InitializeModalPlayer())"
-                   @onclick:preventDefault>View Spectrogram Details</a>
+                   data-regions="@RegionsJson"
+                   onclick="return OpenSpectrogramModal(event, '#@ModalSpectrogramPanelId', '@Detection.Id', '@Detection.AudioUri', this.dataset.regions)">View Spectrogram Details</a>
                 <a class="dropdown-item"
                    href="#@ModalMapPanelId"
                    data-toggle="modal"
@@ -182,10 +180,8 @@
         <a href="@LinkUrl"
            role="button"
            class="btn btn-outline-success"
-           data-toggle="modal"
-           data-target="#@ModalSpectrogramPanelId"
-           @onclick="(()=>InitializeModalPlayer())"
-           @onclick:preventDefault><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
+           data-regions="@RegionsJson"
+           onclick="return OpenSpectrogramModal(event, '#@ModalSpectrogramPanelId', '@Detection.Id', '@Detection.AudioUri', this.dataset.regions)"><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
 
         <a href="#@ModalMapPanelId"
            role="button"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -17,9 +17,11 @@
             <div class="dropdown-menu dropdown-menu-right shadow animated--fade-in"
                  aria-labelledby="dropdownMenuLink">
                 <a class="dropdown-item"
-                   href="#@ModalSpectrogramPanelId"
+                   href="@LinkUrl"
                    data-toggle="modal"
-                   @onclick="(()=>InitializeModalPlayer())">View Spectrogram Details</a>
+                   data-target="#@ModalSpectrogramPanelId"
+                   @onclick="(()=>InitializeModalPlayer())"
+                   @onclick:preventDefault>View Spectrogram Details</a>
                 <a class="dropdown-item"
                    href="#@ModalMapPanelId"
                    data-toggle="modal"
@@ -177,11 +179,13 @@
             </Authorized>
         </AuthorizeView>
 
-        <a href="#@ModalSpectrogramPanelId"
+        <a href="@LinkUrl"
            role="button"
            class="btn btn-outline-success"
            data-toggle="modal"
-           @onclick="(()=>InitializeModalPlayer())"><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
+           data-target="#@ModalSpectrogramPanelId"
+           @onclick="(()=>InitializeModalPlayer())"
+           @onclick:preventDefault><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
 
         <a href="#@ModalMapPanelId"
            role="button"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -120,7 +120,8 @@ public partial class DetectionComponent
 			start = annotation.StartTime,
 			end = annotation.EndTime,
 			drag = false,
-			resize = false
+			resize = false,
+			color = "rgba(255, 255, 255, 0.1)"
 		}));
 
 	private async Task InitializeModalPlayer()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -68,6 +68,14 @@ public partial class DetectionComponent
 			Detection.Found = string.Empty;
 	}
 
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		// Invoked on every render because the card may not be in the DOM yet on the
+		// first render (e.g. while the single detection page is still loading the record);
+		// the JS side is idempotent and exits early once the preview exists.
+		await JSRuntime.InvokeVoidAsync("PreviewCardRegions", _id, Detection.AudioUri, RegionsJson);
+	}
+
 	private void SetFoundValue(string found)
 	{
 		Detection.Found = found;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -106,28 +106,36 @@ public partial class DetectionComponent
 		await JSRuntime.InvokeVoidAsync("ToggleModalSpectrogram");
 	}
 
+	private string RegionsJson
+	{
+		get
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.Append("[");
+
+			var list = new List<string>();
+			foreach(var annotation in Detection.Annotations)
+			{
+				var entry = "{";
+				entry += $"\"start\":{annotation.StartTime}, ";
+				entry += $"\"end\":{annotation.EndTime},";
+				entry += "\"drag\": false";
+				entry += "}";
+				list.Add(entry);
+			}
+			sb.Append(string.Join(",", list));
+
+			sb.AppendLine("]");
+
+			return sb.ToString();
+		}
+	}
+
 	private async Task InitializeModalPlayer()
 	{
-		StringBuilder sb = new StringBuilder();
-		sb.Append("[");
-
-		var list = new List<string>();
-		foreach(var annotation in Detection.Annotations)
-		{
-			var entry = "{";
-			entry += $"\"start\":{annotation.StartTime}, ";
-			entry += $"\"end\":{annotation.EndTime},";
-			entry += "\"drag\": false";
-			entry += "}";
-			list.Add(entry);
-		}
-		sb.Append(string.Join(",", list));
-
-		sb.AppendLine("]");
-
 		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		await JSRuntime.InvokeVoidAsync("InitializeModalSpectrogram", _id, 
-			Detection.AudioUri, sb.ToString());
+		await JSRuntime.InvokeVoidAsync("InitializeModalSpectrogram", _id,
+			Detection.AudioUri, RegionsJson);
 	}
 
 	private async Task InitializeModalMap()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -91,7 +91,7 @@ public partial class DetectionComponent
 
 	private async Task ToggleCardPlayer()
 	{
-		await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri);
+		await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri, RegionsJson);
 	}
 
 	private async Task ToggleModalPlayer()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -111,7 +111,8 @@ public partial class DetectionComponent
 		{
 			start = annotation.StartTime,
 			end = annotation.EndTime,
-			drag = false
+			drag = false,
+			resize = false
 		}));
 
 	private async Task InitializeModalPlayer()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -106,30 +106,13 @@ public partial class DetectionComponent
 		await JSRuntime.InvokeVoidAsync("ToggleModalSpectrogram");
 	}
 
-	private string RegionsJson
-	{
-		get
+	private string RegionsJson =>
+		JsonSerializer.Serialize(Detection.Annotations.Select(annotation => new
 		{
-			StringBuilder sb = new StringBuilder();
-			sb.Append("[");
-
-			var list = new List<string>();
-			foreach(var annotation in Detection.Annotations)
-			{
-				var entry = "{";
-				entry += $"\"start\":{annotation.StartTime}, ";
-				entry += $"\"end\":{annotation.EndTime},";
-				entry += "\"drag\": false";
-				entry += "}";
-				list.Add(entry);
-			}
-			sb.Append(string.Join(",", list));
-
-			sb.AppendLine("]");
-
-			return sb.ToString();
-		}
-	}
+			start = annotation.StartTime,
+			end = annotation.EndTime,
+			drag = false
+		}));
 
 	private async Task InitializeModalPlayer()
 	{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -57,7 +57,7 @@
 	<!-- SB Admin JavaScript -->
 	<script src="js/sb-admin-2.js"></script>
 
-	<script src="js/ai-for-orcas.js"></script>
+	<script src="js/ai-for-orcas.js" asp-append-version="true"></script>
 
 </body>
 </html>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -41,6 +41,9 @@
 		<a class="dismiss">🗙</a>
 	</div>
 
+	<!-- Loaded before blazor.server.js so interop functions exist before the circuit's first render -->
+	<script src="~/js/ai-for-orcas.js" asp-append-version="true"></script>
+
 	<script src="_framework/blazor.server.js"></script>
 
 	<!-- Core JavaScript -->
@@ -56,8 +59,6 @@
 
 	<!-- SB Admin JavaScript -->
 	<script src="js/sb-admin-2.js"></script>
-
-	<script src="~/js/ai-for-orcas.js" asp-append-version="true"></script>
 
 </body>
 </html>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -57,7 +57,7 @@
 	<!-- SB Admin JavaScript -->
 	<script src="js/sb-admin-2.js"></script>
 
-	<script src="js/ai-for-orcas.js" asp-append-version="true"></script>
+	<script src="~/js/ai-for-orcas.js" asp-append-version="true"></script>
 
 </body>
 </html>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -232,7 +232,7 @@ function ToggleModalSpectrogram() {
 	}
 }
 
-function CardSpectrogram(cardId, audioUrl) {
+function CardSpectrogram(cardId, audioUrl, regionsJson) {
 
 	var containerId = 'card-' + cardId;
 
@@ -253,7 +253,12 @@ function CardSpectrogram(cardId, audioUrl) {
 			height: spectrogram.height,
 			maxCanvasWidth: spectrogram.width,
 			responsive: true,
-			fillParent: true
+			fillParent: true,
+			plugins: [
+				WaveSurfer.regions.create({
+					regions: JSON.parse(regionsJson || '[]')
+				})
+			]
 		})
 
 		wavesurfer.containerId = containerId;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -286,7 +286,7 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 				strip.style.height = '100%';
 				strip.style.left = (region.start / duration * 100) + '%';
 				strip.style.width = ((region.end - region.start) / duration * 100) + '%';
-				strip.style.backgroundColor = 'rgba(0, 0, 0, 0.1)';
+				strip.style.backgroundColor = region.color;
 				preview.appendChild(strip);
 			});
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -301,3 +301,15 @@ function CardSpectrogram(cardId, audioUrl) {
 
 
 // Set new default font family and font color to mimic Bootstrap's default styling
+
+function OpenSpectrogramModal(event, modalId, detectionId, audioUrl, regionsJson) {
+	// Ctrl/Cmd/Shift clicks open the details page in a new tab or window instead.
+	if (event.ctrlKey || event.metaKey || event.shiftKey) {
+		return true;
+	}
+
+	DestroyActivePlayer();
+	InitializeModalSpectrogram(detectionId, audioUrl, regionsJson);
+	$(modalId).modal('show');
+	return false;
+}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -302,14 +302,14 @@ function CardSpectrogram(cardId, audioUrl) {
 
 // Set new default font family and font color to mimic Bootstrap's default styling
 
-function OpenSpectrogramModal(event, modalId, detectionId, audioUrl, regionsJson) {
+function OpenSpectrogramModal(event, anchor) {
 	// Ctrl/Cmd/Shift clicks open the details page in a new tab or window instead.
 	if (event.ctrlKey || event.metaKey || event.shiftKey) {
 		return true;
 	}
 
 	DestroyActivePlayer();
-	InitializeModalSpectrogram(detectionId, audioUrl, regionsJson);
-	$(modalId).modal('show');
+	InitializeModalSpectrogram(anchor.dataset.detectionId, anchor.dataset.audioUri, anchor.dataset.regions);
+	$(anchor.dataset.modalTarget).modal('show');
 	return false;
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -232,9 +232,90 @@ function ToggleModalSpectrogram() {
 	}
 }
 
+/* Card Region Preview (shows detector regions on the static spectrogram before playback) */
+
+function PreviewCardRegions(cardId, audioUrl, regionsJson) {
+
+	var regions = JSON.parse(regionsJson || '[]');
+
+	if (regions.length === 0) {
+		return;
+	}
+
+	var image = document.getElementById('spectrogram-card-' + cardId);
+	var waveform = document.getElementById('waveform-card-' + cardId);
+
+	if (image === null || waveform === null || document.getElementById('regions-preview-card-' + cardId) !== null) {
+		return;
+	}
+
+	// The player draws its own regions; skip the preview while it is active on this card
+	if (wavesurfer.containerId == 'card-' + cardId) {
+		return;
+	}
+
+	// preload="metadata" fetches only the audio header, enough to know the clip duration
+	var audio = document.createElement('audio');
+	audio.preload = 'metadata';
+	audio.src = audioUrl;
+
+	audio.addEventListener('loadedmetadata', function () {
+
+		var duration = audio.duration;
+
+		if (!isFinite(duration) || duration <= 0) {
+			return;
+		}
+
+		var draw = function () {
+
+			if (wavesurfer.containerId == 'card-' + cardId || document.getElementById('regions-preview-card-' + cardId) !== null) {
+				return;
+			}
+
+			var preview = document.createElement('div');
+			preview.id = 'regions-preview-card-' + cardId;
+			preview.style.position = 'relative';
+			preview.style.height = image.clientHeight + 'px';
+
+			regions.forEach(function (region) {
+				var strip = document.createElement('div');
+				strip.className = 'wavesurfer-region';
+				strip.style.position = 'absolute';
+				strip.style.top = '0';
+				strip.style.height = '100%';
+				strip.style.left = (region.start / duration * 100) + '%';
+				strip.style.width = ((region.end - region.start) / duration * 100) + '%';
+				strip.style.backgroundColor = 'rgba(0, 0, 0, 0.1)';
+				preview.appendChild(strip);
+			});
+
+			waveform.parentElement.insertBefore(preview, waveform);
+		};
+
+		if (image.complete) {
+			draw();
+		}
+		else {
+			image.addEventListener('load', draw, { once: true });
+		}
+	});
+}
+
+function RemoveCardRegionPreview(cardId) {
+
+	var preview = document.getElementById('regions-preview-card-' + cardId);
+
+	if (preview !== null) {
+		preview.remove();
+	}
+}
+
 function CardSpectrogram(cardId, audioUrl, regionsJson) {
 
 	var containerId = 'card-' + cardId;
+
+	RemoveCardRegionPreview(cardId);
 
 	if (wavesurfer.container != undefined && wavesurfer.containerId != containerId) {
 		DestroyActivePlayer();


### PR DESCRIPTION
## Problem

Fixes #555

The Details button (and the View Spectrogram Details menu item) is an anchor whose href is only the modal hash fragment (`#spectrogram-panel-modal-<id>`). A normal click opens the modal, but "open link in new tab", middle-click, and ctrl+click follow the href and just reload the candidates page.

## Solution

- Both anchors now point at the existing details route (`/detections/detection/{id}`, via the existing `LinkUrl` property)
- A new modifier-aware `OpenSpectrogramModal` JavaScript handler keeps the in-page behavior: plain click opens the modal with the player; ctrl/cmd/shift+click, middle-click, and "open in new tab" go to the details page
- Annotation regions are rendered into a `data-regions` attribute (logic extracted into a `RegionsJson` property) so the handler can initialize the player without a server round trip
- `ai-for-orcas.js` is now referenced with `asp-append-version="true"`, so browsers pick up script changes instead of serving a stale cached copy

## Additions since the PR was opened

After talking to Isabelle (moderator) about how she reviews detections, the scope grew to cover the visible gap between the modal and the other spectrogram views:

- Detector annotation regions now render on the card spectrogram player everywhere (previously modal-only), and as a static preview over the spectrogram image before playback starts, so a detection can be judged from the image alone
- Regions are display-only again: `resize: false` restores the behavior described in the 2021 release notes (the plugin default had been re-exposing resize handles)
- Region color is single-sourced through the region JSON so preview and player render identically
- All four Copilot review comments addressed (culture-safe JSON serialization, `data-*` attributes, parameter rename, app-rooted script path)
- `ai-for-orcas.js` now loads before `blazor.server.js`: the region preview is invoked from `OnAfterRenderAsync`, which could fire before the script finished loading and killed the circuit with "Could not find 'PreviewCardRegions'"

The remaining moderator asks are tracked separately: #554 (queue position lost on back navigation) and #563 (spectrogram zoom).

## Verification

Manually verified on a local run of AIForOrcas.Client.Web:

- Plain click: modal opens with spectrogram and player, URL unchanged
- Ctrl+click / shift+click / middle-click / open in new tab: details page renders
- Regions render on candidate cards, details page, and modal, with preview strips before playback and identical styling during playback
- Submitting a moderation from the details page persists and the shared link still renders after moderation
- Map and Show Links: unchanged
- Script tag renders with a content-hash version query; cold-cache loads no longer crash the circuit

No test project exists for AIForOrcas.Client.Web, so no automated tests are included.