### PR TITLE
Fix invisible spectrogram region shades and silent audio load failures

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -414,12 +414,16 @@ function OpenSpectrogramModal(event, anchor) {
 	InitializeModalSpectrogram(anchor.dataset.detectionId, anchor.dataset.audioUri, anchor.dataset.regions);
 	$(anchor.dataset.modalTarget).modal('show');
 
+	var containerId = 'modal-' + anchor.dataset.detectionId;
+
 	// The player is created while the modal is still hidden, so it measures a
 	// zero-width container. If the audio gets ready before the modal fade ends,
 	// the waveform and its regions keep that zero width and the shades render
 	// invisible. Re-measure and redraw once the modal is actually visible.
+	// The containerId check makes sure the player still belongs to this modal
+	// in case another one was initialized before this modal finished showing.
 	$(anchor.dataset.modalTarget).one('shown.bs.modal', function () {
-		if (IsPlayerActive()) {
+		if (IsPlayerActive() && wavesurfer.containerId == containerId) {
 			ResizeActivePlayer();
 			if (wavesurfer.isReady) {
 				wavesurfer.drawBuffer();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -207,6 +207,13 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 		SetDuration();
 	});
 
+	// If the audio fails to load, reset the button so the failure is visible
+	// instead of leaving the spinner stuck forever.
+	wavesurfer.on('error', function (e) {
+		console.error('Spectrogram audio failed to load: ' + e);
+		SetSpinnerButtonToPlay();
+	});
+
 	// when something is happening, update
 	wavesurfer.on('audioprocess', function () {
 		SetElapsedTime();
@@ -315,8 +322,6 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 
 	var containerId = 'card-' + cardId;
 
-	RemoveCardRegionPreview(cardId);
-
 	if (wavesurfer.container != undefined && wavesurfer.containerId != containerId) {
 		DestroyActivePlayer();
 	}
@@ -353,7 +358,18 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 			AdjustSizes(spectrogram);
 			SetSpinnerButtonToPause();
 			SetDuration();
+			// Swap the static region preview for the player's own regions only
+			// once they can actually render, so the shades never blink out.
+			RemoveCardRegionPreview(cardId);
 			wavesurfer.play();
+		});
+
+		// If the audio fails to load, reset the button so the failure is visible
+		// instead of leaving the spinner stuck forever. The static region
+		// preview is intentionally left in place.
+		wavesurfer.on('error', function (e) {
+			console.error('Spectrogram audio failed to load: ' + e);
+			SetSpinnerButtonToPlay();
 		});
 
 		// when done playing, reset everything
@@ -397,5 +413,18 @@ function OpenSpectrogramModal(event, anchor) {
 	DestroyActivePlayer();
 	InitializeModalSpectrogram(anchor.dataset.detectionId, anchor.dataset.audioUri, anchor.dataset.regions);
 	$(anchor.dataset.modalTarget).modal('show');
+
+	// The player is created while the modal is still hidden, so it measures a
+	// zero-width container. If the audio gets ready before the modal fade ends,
+	// the waveform and its regions keep that zero width and the shades render
+	// invisible. Re-measure and redraw once the modal is actually visible.
+	$(anchor.dataset.modalTarget).one('shown.bs.modal', function () {
+		if (IsPlayerActive()) {
+			ResizeActivePlayer();
+			if (wavesurfer.isReady) {
+				wavesurfer.drawBuffer();
+			}
+		}
+	});
 	return false;
 }


### PR DESCRIPTION
Fixes #568

Three small changes in ai-for-orcas.js:

1. **Re-measure the modal player once the modal is visible.** The player is created before `modal('show')`, so wavesurfer measures the hidden container (width 0). When the audio's ready event fires before the modal fade completes (cached or fast audio), regions were laid out in a zero-width waveform and rendered as invisible 2px slivers. A one-shot `shown.bs.modal` handler now resizes and redraws the waveform, so the shades are correct regardless of which finishes first.

2. **Handle audio load errors.** Neither player registered a wavesurfer `error` handler, so a failed fetch or decode left the play button on the spinner forever with no feedback. Both players now log the error and reset the button to the play icon.

3. **Remove the static region preview only when the player is ready.** The preview from #559 was removed as soon as play was clicked, but the player's own regions only appear once the audio is loaded, so the shades blinked out during load. The preview now stays until the regions can actually render, and it survives a failed load.

Tested locally: repeated modal open/close on cached audio always shows the shades; simulated network failure resets the button and keeps the preview; play on a card keeps shades visible through loading with no blink.