### PR TITLE
fix: keep spectrogram shades aligned by drawing them once over the image

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -21,7 +21,6 @@
                    data-modal-target="#@ModalSpectrogramPanelId"
                    data-detection-id="@Detection.Id"
                    data-audio-uri="@Detection.AudioUri"
-                   data-regions="@RegionsJson"
                    onclick="return OpenSpectrogramModal(event, this)">View Spectrogram Details</a>
                 <a class="dropdown-item"
                    href="#@ModalMapPanelId"
@@ -218,7 +217,6 @@
            data-modal-target="#@ModalSpectrogramPanelId"
            data-detection-id="@Detection.Id"
            data-audio-uri="@Detection.AudioUri"
-           data-regions="@RegionsJson"
            onclick="return OpenSpectrogramModal(event, this)"><i class="fas fa-wave-square pr-2" aria-hidden="true"></i>Details</a>
 
         <a href="#@ModalMapPanelId"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -134,8 +134,8 @@ public partial class DetectionComponent
 	{
 		// Invoked on every render because the card may not be in the DOM yet on the
 		// first render (e.g. while the single detection page is still loading the record);
-		// the JS side is idempotent and exits early once the preview exists.
-		await JSRuntime.InvokeVoidAsync("PreviewCardRegions", _id, Detection.AudioUri, RegionsJson);
+		// the JS side is idempotent and exits early once the shades exist.
+		await JSRuntime.InvokeVoidAsync("DrawRegionShades", _id, Detection.AudioUri, RegionsJson);
 	}
 
 	private void SetFoundValue(string found)
@@ -292,7 +292,7 @@ public partial class DetectionComponent
 
 	private async Task ToggleCardPlayer()
 	{
-		await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri, RegionsJson);
+		await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri);
 	}
 
 	private async Task ToggleModalPlayer()
@@ -312,8 +312,6 @@ public partial class DetectionComponent
 		{
 			start = annotation.StartTime,
 			end = annotation.EndTime,
-			drag = false,
-			resize = false,
 			color = "rgba(255, 255, 255, 0.1)"
 		}));
 
@@ -321,7 +319,7 @@ public partial class DetectionComponent
 	{
 		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
 		await JSRuntime.InvokeVoidAsync("InitializeModalSpectrogram", _id,
-			Detection.AudioUri, RegionsJson);
+			Detection.AudioUri);
 	}
 
 	private async Task InitializeModalMap()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -52,7 +52,6 @@
 
 	<!-- Wavesurfer -->
 	<script src="vendor/wavesurfer/wavesurfer.js"></script>
-	<script src="vendor/wavesurfer/wavesurfer.regions.min.js"></script>
 
 	<!-- Bing maps -->
 	<script src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=AjPZqXS-Xf1kvUrAxtnogaAA9S1COo2L3md5YFDg7O7HJFOgWMzbprOnpp4epSbv' type='text/javascript'></script>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -161,22 +161,13 @@ function DestroyActivePlayer() {
 		ResetElapsedTime();
 		ResetDuration();
 
-		// Destroying a card player takes its regions with it; bring the static
-		// preview back so the detector shades stay visible after playback ends
-		// or moves to another card or modal.
-		var previewArgs = wavesurfer.previewArgs;
-
 		wavesurfer.destroy();
 
 		wavesurfer = {};
-
-		if (previewArgs != undefined) {
-			PreviewCardRegions.apply(null, previewArgs);
-		}
 	}
 }
 
-function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
+function InitializeModalSpectrogram(modalId, audioUrl) {
 
 	var containerId = 'modal-' + modalId;
 
@@ -186,12 +177,9 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 
 	var spectrogram = new Spectrogram(containerId);
 
-	// The regions are drawn before the audio duration is known, so they collapse
-	// at the left edge until 'ready'. Hide the player while it loads so the
-	// misdrawn regions are never shown.
-	var waveform = document.getElementById('waveform-' + containerId);
-	waveform.style.visibility = 'hidden';
-
+	// The detector shades are drawn over the spectrogram image by
+	// DrawRegionShades; the player only contributes the progress cursor
+	// and the audio itself, so no regions plugin is needed.
 	wavesurfer = WaveSurfer.create({
 		container: '#waveform-' + containerId,
 		waveColor: 'rgba(0,0,0,0)',
@@ -201,12 +189,7 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 		height: spectrogram.height,
 		maxCanvasWidth: spectrogram.width,
 		responsive: true,
-		fillParent: true,
-		plugins: [
-			WaveSurfer.regions.create({
-				regions: JSON.parse(regionsJson)
-			})
-		]
+		fillParent: true
 	})
 
 	wavesurfer.containerId = containerId;
@@ -218,7 +201,6 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 	wavesurfer.on('ready', function () {
 		SetMaximumVolume();
 		AdjustSizes(spectrogram);
-		waveform.style.visibility = '';
 		SetSpinnerButtonToPlay();
 		SetDuration();
 	});
@@ -255,9 +237,14 @@ function ToggleModalSpectrogram() {
 	}
 }
 
-/* Card Region Preview (shows detector regions on the static spectrogram before playback) */
+/* Region Shades (detector regions drawn over the spectrogram image) */
 
-function PreviewCardRegions(cardId, audioUrl, regionsJson) {
+// The shades are the single source of truth for where the AI heard something:
+// percentage-positioned strips over the responsive spectrogram image, in both
+// the card and its modal, present before, during, and after playback. The
+// player never draws its own regions, so the shades cannot jump, blink, or
+// disappear across the playback lifecycle.
+function DrawRegionShades(detectionId, audioUrl, regionsJson) {
 
 	var regions = JSON.parse(regionsJson || '[]');
 
@@ -265,40 +252,31 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 		return;
 	}
 
-	var image = document.getElementById('spectrogram-card-' + cardId);
-	var waveform = document.getElementById('waveform-card-' + cardId);
+	var drawInto = function (containerId, duration) {
 
-	if (image === null || waveform === null || document.getElementById('regions-preview-card-' + cardId) !== null) {
-		return;
-	}
+		var image = document.getElementById('spectrogram-' + containerId);
+		var waveform = document.getElementById('waveform-' + containerId);
 
-	// The player draws its own regions; skip the preview while it is active on this card
-	if (wavesurfer.containerId == 'card-' + cardId) {
-		return;
-	}
-
-	var drawForDuration = function (duration) {
-
-		if (!isFinite(duration) || duration <= 0) {
+		if (image === null || waveform === null || document.getElementById('regions-shades-' + containerId) !== null) {
 			return;
 		}
 
 		var draw = function () {
 
-			if (wavesurfer.containerId == 'card-' + cardId || document.getElementById('regions-preview-card-' + cardId) !== null) {
+			if (document.getElementById('regions-shades-' + containerId) !== null) {
 				return;
 			}
 
 			// Absolutely positioned over the card-img-overlay, which tracks the
 			// responsive spectrogram image, so the strips follow every resize
 			// and the waveform below is not displaced out of the overlay.
-			var preview = document.createElement('div');
-			preview.id = 'regions-preview-card-' + cardId;
-			preview.style.position = 'absolute';
-			preview.style.top = '0';
-			preview.style.left = '0';
-			preview.style.width = '100%';
-			preview.style.height = '100%';
+			var shades = document.createElement('div');
+			shades.id = 'regions-shades-' + containerId;
+			shades.style.position = 'absolute';
+			shades.style.top = '0';
+			shades.style.left = '0';
+			shades.style.width = '100%';
+			shades.style.height = '100%';
 
 			regions.forEach(function (region) {
 				var strip = document.createElement('div');
@@ -309,10 +287,12 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 				strip.style.left = (region.start / duration * 100) + '%';
 				strip.style.width = ((region.end - region.start) / duration * 100) + '%';
 				strip.style.backgroundColor = region.color;
-				preview.appendChild(strip);
+				shades.appendChild(strip);
 			});
 
-			waveform.parentElement.insertBefore(preview, waveform);
+			// Inserted below the waveform so the progress cursor stays visible
+			// and seek clicks keep landing on the player.
+			waveform.parentElement.insertBefore(shades, waveform);
 		};
 
 		if (image.complete) {
@@ -321,6 +301,16 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 		else {
 			image.addEventListener('load', draw, { once: true });
 		}
+	};
+
+	var drawForDuration = function (duration) {
+
+		if (!isFinite(duration) || duration <= 0) {
+			return;
+		}
+
+		drawInto('card-' + detectionId, duration);
+		drawInto('modal-' + detectionId, duration);
 	};
 
 	// preload="metadata" fetches only the audio header, enough to know the clip duration
@@ -341,16 +331,7 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 	});
 }
 
-function RemoveCardRegionPreview(cardId) {
-
-	var preview = document.getElementById('regions-preview-card-' + cardId);
-
-	if (preview !== null) {
-		preview.remove();
-	}
-}
-
-function CardSpectrogram(cardId, audioUrl, regionsJson) {
+function CardSpectrogram(cardId, audioUrl) {
 
 	var containerId = 'card-' + cardId;
 
@@ -362,13 +343,9 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 
 		var spectrogram = new Spectrogram(containerId);
 
-		// Same loading-window guard as the modal player: the regions collapse at
-		// the left edge until 'ready', and next to the static preview that reads
-		// as the shades blinking and shifting. Keep the player hidden until its
-		// regions are correct; the preview stays as the only visible shading.
-		var waveform = document.getElementById('waveform-' + containerId);
-		waveform.style.visibility = 'hidden';
-
+		// The detector shades are drawn over the spectrogram image by
+		// DrawRegionShades; the player only contributes the progress cursor
+		// and the audio itself, so no regions plugin is needed.
 		wavesurfer = WaveSurfer.create({
 			container: ('#waveform-' + containerId),
 			waveColor: 'rgba(0,0,0,0)',
@@ -378,18 +355,10 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 			height: spectrogram.height,
 			maxCanvasWidth: spectrogram.width,
 			responsive: true,
-			fillParent: true,
-			plugins: [
-				WaveSurfer.regions.create({
-					regions: JSON.parse(regionsJson || '[]')
-				})
-			]
+			fillParent: true
 		})
 
 		wavesurfer.containerId = containerId;
-		// Remembered so DestroyActivePlayer can restore the static preview
-		// this player replaces.
-		wavesurfer.previewArgs = [cardId, audioUrl, regionsJson];
 
 		SetPlayButtonToSpinner();
 
@@ -400,16 +369,12 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 			AdjustSizes(spectrogram);
 			SetSpinnerButtonToPause();
 			SetDuration();
-			// Swap the static region preview for the player's own regions only
-			// once they can actually render, so the shades never blink out.
-			RemoveCardRegionPreview(cardId);
-			waveform.style.visibility = '';
 			wavesurfer.play();
 		});
 
 		// If the audio fails to load, reset the button so the failure is visible
-		// instead of leaving the spinner stuck forever. The static region
-		// preview is intentionally left in place.
+		// instead of leaving the spinner stuck forever. The region shades stay
+		// in place either way.
 		wavesurfer.on('error', function (e) {
 			console.error('Spectrogram audio failed to load: ' + e);
 			SetSpinnerButtonToPlay();
@@ -454,14 +419,14 @@ function OpenSpectrogramModal(event, anchor) {
 	}
 
 	DestroyActivePlayer();
-	InitializeModalSpectrogram(anchor.dataset.detectionId, anchor.dataset.audioUri, anchor.dataset.regions);
+	InitializeModalSpectrogram(anchor.dataset.detectionId, anchor.dataset.audioUri);
 	$(anchor.dataset.modalTarget).modal('show');
 
 	var containerId = 'modal-' + anchor.dataset.detectionId;
 
 	// The player is created while the modal is still hidden, so it measures a
 	// zero-width container. If the audio gets ready before the modal fade ends,
-	// the waveform and its regions keep that zero width and the shades render
+	// the waveform keeps that zero width and the progress cursor renders
 	// invisible. Re-measure and redraw once the modal is actually visible.
 	// The containerId check makes sure the player still belongs to this modal
 	// in case another one was initialized before this modal finished showing.

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -189,7 +189,10 @@ function InitializeModalSpectrogram(modalId, audioUrl) {
 		height: spectrogram.height,
 		maxCanvasWidth: spectrogram.width,
 		responsive: true,
-		fillParent: true
+		fillParent: true,
+		// Clip instead of scroll: a window drag can briefly leave the canvas
+		// wider than its container, blinking a scrollbar under the spectrogram.
+		hideScrollbar: true
 	})
 
 	wavesurfer.containerId = containerId;
@@ -366,7 +369,9 @@ function CardSpectrogram(cardId, audioUrl) {
 			height: spectrogram.height,
 			maxCanvasWidth: spectrogram.width,
 			responsive: true,
-			fillParent: true
+			fillParent: true,
+			// Same as the modal player: no scrollbar blink on resize.
+			hideScrollbar: true
 		})
 
 		wavesurfer.containerId = containerId;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -151,6 +151,13 @@ function ResizeActivePlayer() {
 	if (wavesurfer.container != undefined) {
 		spectrogram = new Spectrogram(wavesurfer.containerId);
 		AdjustSizes(spectrogram);
+		// Redraw now instead of waiting for wavesurfer's debounced responsive
+		// redraw, so the progress cursor tracks the scaling image during a
+		// drag. Same event the debounced handler fires, which redraws the
+		// waveform and repositions the progress cursor.
+		if (wavesurfer.isReady) {
+			wavesurfer.drawer.fireEvent('redraw');
+		}
 	}
 }
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -161,9 +161,18 @@ function DestroyActivePlayer() {
 		ResetElapsedTime();
 		ResetDuration();
 
+		// Destroying a card player takes its regions with it; bring the static
+		// preview back so the detector shades stay visible after playback ends
+		// or moves to another card or modal.
+		var previewArgs = wavesurfer.previewArgs;
+
 		wavesurfer.destroy();
 
 		wavesurfer = {};
+
+		if (previewArgs != undefined) {
+			PreviewCardRegions.apply(null, previewArgs);
+		}
 	}
 }
 
@@ -261,14 +270,7 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 		return;
 	}
 
-	// preload="metadata" fetches only the audio header, enough to know the clip duration
-	var audio = document.createElement('audio');
-	audio.preload = 'metadata';
-	audio.src = audioUrl;
-
-	audio.addEventListener('loadedmetadata', function () {
-
-		var duration = audio.duration;
+	var drawForDuration = function (duration) {
 
 		if (!isFinite(duration) || duration <= 0) {
 			return;
@@ -280,10 +282,16 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 				return;
 			}
 
+			// Absolutely positioned over the card-img-overlay, which tracks the
+			// responsive spectrogram image, so the strips follow every resize
+			// and the waveform below is not displaced out of the overlay.
 			var preview = document.createElement('div');
 			preview.id = 'regions-preview-card-' + cardId;
-			preview.style.position = 'relative';
-			preview.style.height = image.clientHeight + 'px';
+			preview.style.position = 'absolute';
+			preview.style.top = '0';
+			preview.style.left = '0';
+			preview.style.width = '100%';
+			preview.style.height = '100%';
 
 			regions.forEach(function (region) {
 				var strip = document.createElement('div');
@@ -306,6 +314,23 @@ function PreviewCardRegions(cardId, audioUrl, regionsJson) {
 		else {
 			image.addEventListener('load', draw, { once: true });
 		}
+	};
+
+	// preload="metadata" fetches only the audio header, enough to know the clip duration
+	var audio = document.createElement('audio');
+	audio.preload = 'metadata';
+	audio.src = audioUrl;
+
+	audio.addEventListener('loadedmetadata', function () {
+		drawForDuration(audio.duration);
+	});
+
+	// If the audio cannot load at all, still show where the AI heard something.
+	// Every deployment produces 60 second clips (inference_segment_size), so a
+	// fixed fallback keeps the strips close to their real place until playback
+	// becomes available again.
+	audio.addEventListener('error', function () {
+		drawForDuration(60);
 	});
 }
 
@@ -348,6 +373,9 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 		})
 
 		wavesurfer.containerId = containerId;
+		// Remembered so DestroyActivePlayer can restore the static preview
+		// this player replaces.
+		wavesurfer.previewArgs = [cardId, audioUrl, regionsJson];
 
 		SetPlayButtonToSpinner();
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -252,6 +252,17 @@ function DrawRegionShades(detectionId, audioUrl, regionsJson) {
 		return;
 	}
 
+	// Blazor re-renders the component many times; once every present container
+	// has its shades there is nothing left to draw, so skip the metadata probe.
+	var needsShades = function (containerId) {
+		return document.getElementById('spectrogram-' + containerId) !== null
+			&& document.getElementById('regions-shades-' + containerId) === null;
+	};
+
+	if (!needsShades('card-' + detectionId) && !needsShades('modal-' + detectionId)) {
+		return;
+	}
+
 	var drawInto = function (containerId, duration) {
 
 		var image = document.getElementById('spectrogram-' + containerId);

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -186,6 +186,12 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 
 	var spectrogram = new Spectrogram(containerId);
 
+	// The regions are drawn before the audio duration is known, so they collapse
+	// at the left edge until 'ready'. Hide the player while it loads so the
+	// misdrawn regions are never shown.
+	var waveform = document.getElementById('waveform-' + containerId);
+	waveform.style.visibility = 'hidden';
+
 	wavesurfer = WaveSurfer.create({
 		container: '#waveform-' + containerId,
 		waveColor: 'rgba(0,0,0,0)',
@@ -212,6 +218,7 @@ function InitializeModalSpectrogram(modalId, audioUrl, regionsJson) {
 	wavesurfer.on('ready', function () {
 		SetMaximumVolume();
 		AdjustSizes(spectrogram);
+		waveform.style.visibility = '';
 		SetSpinnerButtonToPlay();
 		SetDuration();
 	});
@@ -355,6 +362,13 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 
 		var spectrogram = new Spectrogram(containerId);
 
+		// Same loading-window guard as the modal player: the regions collapse at
+		// the left edge until 'ready', and next to the static preview that reads
+		// as the shades blinking and shifting. Keep the player hidden until its
+		// regions are correct; the preview stays as the only visible shading.
+		var waveform = document.getElementById('waveform-' + containerId);
+		waveform.style.visibility = 'hidden';
+
 		wavesurfer = WaveSurfer.create({
 			container: ('#waveform-' + containerId),
 			waveColor: 'rgba(0,0,0,0)',
@@ -389,6 +403,7 @@ function CardSpectrogram(cardId, audioUrl, regionsJson) {
 			// Swap the static region preview for the player's own regions only
 			// once they can actually render, so the shades never blink out.
 			RemoveCardRegionPreview(cardId);
+			waveform.style.visibility = '';
 			wavesurfer.play();
 		});
 


### PR DESCRIPTION
Fixes #578

## Problem

The detection shades were drawn by two different systems: static strips over the spectrogram image before playback, and wavesurfer's regions plugin once a player was active. Every symptom in #578 comes from the handoff between the two:

- The static strips were sized in frozen pixels at creation time, so resizing or zooming the window left them misaligned with the responsive image, and pushed the waveform below the spectrogram.
- Pressing play swapped the strips for plugin regions. Wavesurfer 2 draws those at player creation, before the audio duration is known, so they render as ~2px slivers at the left edge until the `ready` event. On a slow connection that window lasts seconds. This also happens in production today, it is just hard to notice without the static strips next to it.
- When playback finished, moved to another card, or the audio failed to load, the removal/restore glue missed cases and the shades disappeared entirely.

## Change

Make the image shades the single source of truth and remove the regions plugin:

- `DrawRegionShades` draws percentage-positioned strips over the spectrogram image, for the card and the modal, once. Percentage units mean they track the responsive image through any resize or zoom with no JS resize handling.
- The clip duration comes from an `<audio preload="metadata">` probe, with a 60 second fallback (the inference segment size) if the audio fails to load, so shades still appear when the clip is unreachable.
- The players no longer load the regions plugin, and all swap/restore glue is gone. Play, finish, destroy, and card switches cannot move, blink, or drop a shade because nothing about playback touches the shades anymore.
- The progress cursor still comes from the player and sweeps over the static shades, so playback feedback is unchanged.

Region drag/resize was already disabled, so no interactive behavior is lost by dropping the plugin.

## How to test

1. Open the candidates page and pick a card with detection annotations (shaded bars over the spectrogram).
2. Resize the browser window from narrow to wide, and back. The shades should stretch with the image and stay on the annotation times, and the waveform should stay on top of the spectrogram instead of dropping below it.
3. Press play. The shades should not flash, shift, or get replaced; the white cursor sweeps over them.
4. Let the clip finish, then play a different card. The shades on both cards should still be there, unchanged.
5. Open the spectrogram modal from the card menu. The shades should cover the full image height at the same times.
6. Optional: block the audio URL in DevTools and reload. The shades still render, positioned against the 60 second segment length.