### PR TITLE
Improve pagination navigation

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
@@ -36,8 +36,10 @@ public partial class PaginationComponent
 
 		for (int i = 1; i <= PaginationResults.TotalNumberOfPages; i++)
 		{
-			if (i >= PaginationResults.CurrentPage - PaginationOptions.Radius && 
-				i <= PaginationResults.CurrentPage + PaginationOptions.Radius)
+			if (i == 1 ||
+				i == PaginationResults.TotalNumberOfPages ||
+				(i >= PaginationResults.CurrentPage - PaginationOptions.Radius &&
+				 i <= PaginationResults.CurrentPage + PaginationOptions.Radius))
 			{
 				links.Add(new PageLinkDTO(i) { Active = PaginationResults.CurrentPage == i });
 			}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor
@@ -13,6 +13,16 @@
 }
 else
 {
+	<!-- Pagination -->
+        @if (detections != null && detections.Count > 0)
+        {
+                <div class="col-12 text-left px-0">
+                        <PaginationComponent PaginationOptions=@paginationOptions
+                                             PaginationResults="@pagination"
+                                             SelectPageCallback="ActOnSelectPageCallback" />
+                </div>
+        }
+
 	<!-- Cards -->
 	@for (var i = 0; i < detections.Count(); i++)
 	{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor
@@ -12,6 +12,16 @@
 }
 else
 {
+	<!-- Pagination -->
+	@if (detections != null && detections.Count > 0)
+	{
+		<div class="col-12 text-left px-0">
+			<PaginationComponent PaginationOptions=@paginationOptions
+								PaginationResults="@pagination"
+								SelectPageCallback="ActOnSelectPageCallback" />
+		</div>
+	}
+
 	<!-- Cards -->
 	@for (var i = 0; i < detections.Count(); i++)
 	{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor
@@ -12,6 +12,16 @@
 }
 else
 {
+    <!-- Pagination -->
+    @if (detections != null && detections.Count > 0)
+    {
+        <div class="col-12 text-left px-0">
+            <PaginationComponent PaginationOptions=@paginationOptions
+                                PaginationResults="@pagination"
+                                SelectPageCallback="ActOnSelectPageCallback" />
+        </div>
+    }
+
     <!-- Cards -->
     @for (var i = 0; i < detections.Count(); i++)
     {

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor
@@ -12,6 +12,16 @@
 }
 else
 {
+	<!-- Pagination -->
+	@if (detections != null && detections.Count > 0)
+	{
+		<div class="col-12 text-left px-0">
+			<PaginationComponent PaginationOptions=@paginationOptions
+								PaginationResults="@pagination"
+								SelectPageCallback="ActOnSelectPageCallback" />
+		</div>
+	}
+
 	<!-- Cards -->
 	@for (var i = 0; i < detections.Count(); i++)
 	{


### PR DESCRIPTION
Adds pagination controls above the detection lists so it is accessible without scrolling down to the bottom.

Also keeps the first and last page link visible, allowing the moderators to jump directly between first and the last page for a longer result set.

Tested locally:
- Release build succeeds.
- win-x86 restore/build/test commands are completed successfully.
- Manually verified the pagination and navigation of the pages.

Closes #583