### PR TITLE
Stop audio after candidate submission

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -93,6 +93,7 @@ public partial class Candidates : IDisposable
 
 		ToastService.ShowSuccess("Detection successfully updated.");
 
+		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
 		await LoadDetections();
 	}
 


### PR DESCRIPTION
## Summary

- destroy the active WaveSurfer player after a candidate update succeeds
- do the teardown before reloading the detection list removes the player's card
- leave playback untouched when the update request fails

Fixes #592.

## Validation

- `dotnet restore -r win-x86`
- `dotnet build --no-restore -c Release -r win-x86` (0 errors; existing net6/toolchain warnings remain)
- `dotnet test --no-restore -r win-x86` (completed successfully; the solution has no test projects)
- `dotnet publish --no-restore -c Release -r win-x86 -o /tmp/orcahello-592-publish`
- targeted submit-order assertion: `origin/main` fails the required successful-update → player-teardown → list-reload sequence; this patch passes it

## AI assistance

Codex (GPT-5) identified the missing lifecycle call, applied the one-line patch, and ran the validation above.
