### PR TITLE
feat: start card spectrogram playback at the touched point before Play is pressed

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -43,7 +43,10 @@
                         <img class="img-fluid"
                              id=@CardSpectrogramId
                              src=@Detection.SpectrogramUri />
-                        <div class="card-img-overlay p-0">
+                        <div class="card-img-overlay p-0"
+                             data-detection-id="@Detection.Id"
+                             data-audio-uri="@Detection.AudioUri"
+                             onclick="CardSpectrogramTouch(event, this)">
                             <div id=@CardWaveformId class="d-block"></div>
                         </div>
                     </div>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -411,11 +411,15 @@ function CardSpectrogram(cardId, audioUrl, startFraction) {
 			SetSpinnerButtonToPause();
 			SetDuration();
 			// A touch created this player carrying where it landed; start
-			// playback from that point (seekTo takes a 0..1 progress).
+			// playback from that point (seekTo takes a 0..1 progress). The
+			// seek handler below already calls play(), so calling it again
+			// here would start a second buffer source.
 			if (startFraction > 0) {
 				wavesurfer.seekTo(startFraction);
 			}
-			wavesurfer.play();
+			else {
+				wavesurfer.play();
+			}
 		});
 
 		// If the audio fails to load, reset the button so the failure is visible

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -352,7 +352,25 @@ function DrawRegionShades(detectionId, audioUrl, regionsJson) {
 	});
 }
 
-function CardSpectrogram(cardId, audioUrl) {
+// Touch on a card spectrogram that has no player yet: create the player and
+// start playback at the touched point, like the modal spectrogram does. When
+// this card's player already exists, wavesurfer's own click-to-seek on the
+// waveform handles the touch, so do nothing here.
+function CardSpectrogramTouch(event, overlay) {
+
+	var containerId = 'card-' + overlay.dataset.detectionId;
+
+	if (wavesurfer.container != undefined && wavesurfer.containerId == containerId) {
+		return;
+	}
+
+	var rect = overlay.getBoundingClientRect();
+	var fraction = (event.clientX - rect.left) / rect.width;
+
+	CardSpectrogram(overlay.dataset.detectionId, overlay.dataset.audioUri, fraction);
+}
+
+function CardSpectrogram(cardId, audioUrl, startFraction) {
 
 	var containerId = 'card-' + cardId;
 
@@ -392,6 +410,11 @@ function CardSpectrogram(cardId, audioUrl) {
 			AdjustSizes(spectrogram);
 			SetSpinnerButtonToPause();
 			SetDuration();
+			// A touch created this player carrying where it landed; start
+			// playback from that point (seekTo takes a 0..1 progress).
+			if (startFraction > 0) {
+				wavesurfer.seekTo(startFraction);
+			}
 			wavesurfer.play();
 		});
 


### PR DESCRIPTION
Fixes #591.

Touching a candidate's spectrogram before pressing Play now creates the player and starts playback at the touched point, the same way the details spectrogram already behaves. Once the player exists, wavesurfer's own click-to-seek keeps handling touches as before.

The card image overlay passes the touch position as a fraction of its width into `CardSpectrogram`, which seeks there before playing. The Play button and the details modal are unchanged, and the single-active-player behavior stays: touching another card stops the current one and starts the new one at the touched point.

Tested on Android Chrome (portrait) and desktop: fresh-card touch, touch inside a detection shade, seek after Play, Play button from the start, switching cards mid-playback, and the details modal.