### PR TITLE
Keep the moderator portal working when the detections API is unreachable

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/AIForOrcas.Client.BL.csproj
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/AIForOrcas.Client.BL.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -1,5 +1,6 @@
 ﻿using AIForOrcas.DTO;
 using AIForOrcas.DTO.API;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -15,11 +16,13 @@ namespace AIForOrcas.Client.BL.Services
 		private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
 		private readonly IHttpClientFactory _httpClientFactory;
 		private readonly IAuthTokenProvider _authTokenProvider;
+		private readonly ILogger<DetectionService> _logger;
 
-		public DetectionService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider)
+		public DetectionService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider, ILogger<DetectionService> logger)
 		{
 			_httpClientFactory = httpClientFactory;
 			_authTokenProvider = authTokenProvider;
+			_logger = logger;
 		}
 
 		// Get detections based on passed view, pagination options, and filter options
@@ -30,7 +33,19 @@ namespace AIForOrcas.Client.BL.Services
 
 			// Create client on-demand from the current scope.
 			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
-			var httpResponseMessage = await httpClient.GetAsync(url);
+
+			HttpResponseMessage httpResponseMessage;
+			try
+			{
+				httpResponseMessage = await httpClient.GetAsync(url);
+			}
+			catch (HttpRequestException exception)
+			{
+				// An unreachable API must degrade like a failed status code; an
+				// unhandled exception here would take down the whole circuit.
+				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
+				return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
+			}
 
 			if (httpResponseMessage.IsSuccessStatusCode)
 			{
@@ -103,7 +118,18 @@ namespace AIForOrcas.Client.BL.Services
 
 			// Create client on-demand from the current scope.
 			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
-			var httpResponseMessage = await httpClient.GetAsync(url);
+
+			HttpResponseMessage httpResponseMessage;
+			try
+			{
+				httpResponseMessage = await httpClient.GetAsync(url);
+			}
+			catch (HttpRequestException exception)
+			{
+				// Degrade to the not-found shape rather than killing the circuit.
+				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
+				return new Detection();
+			}
 
 			if (httpResponseMessage.IsSuccessStatusCode)
 			{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -131,12 +131,21 @@ namespace AIForOrcas.Client.BL.Services
 				throw new HttpRequestException(
 					$"Failed to update detection. The request to {url} timed out.", exception);
 			}
+			catch (HttpRequestException exception)
+			{
+				// The UI suppresses this into a toast, so log it here or the
+				// failure never reaches the server diagnostics.
+				_logger.LogError(exception, "Unable to reach the detections API to update at {Url}", url);
+				throw;
+			}
 
 			if (!httpResponseMessage.IsSuccessStatusCode)
 			{
 				var errorContent = await httpResponseMessage.Content.ReadAsStringAsync();
 				var statusCode = (int)httpResponseMessage.StatusCode;
 
+				_logger.LogError("The detections API rejected the update at {Url} with {StatusCode}: {Details}",
+					url, statusCode, errorContent);
 				throw new HttpRequestException(
 					$"Failed to update detection. Status: {statusCode} {httpResponseMessage.ReasonPhrase}. Details: {errorContent}");
 			}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -124,10 +124,9 @@ namespace AIForOrcas.Client.BL.Services
 			}
 			catch (TaskCanceledException exception)
 			{
-				// A timed-out PUT surfaces as a canceled task, and Blazor drops
-				// canceled event tasks without running any catch block, so the
-				// caller would never learn the update was lost. Rethrowing as a
-				// request failure keeps the task faulted and lets callers react.
+				// A timed-out PUT surfaces as a canceled task. Rethrow it as a
+				// request failure so callers handle one exception type for "the
+				// update was lost", whether the API refused or timed out.
 				_logger.LogError(exception, "Timed out updating the detection at {Url}", url);
 				throw new HttpRequestException(
 					$"Failed to update detection. The request to {url} timed out.", exception);
@@ -182,10 +181,18 @@ namespace AIForOrcas.Client.BL.Services
 					return null;
 				}
 			}
+			else if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NotFound)
+			{
+				// The API answered 404: this id genuinely has no detection.
+				return new Detection();
+			}
 			else
 			{
-				// The API answered: this id genuinely has no detection.
-				return new Detection();
+				// Any other error status is the API failing, not a missing
+				// record; report it like an unreachable API.
+				_logger.LogError("The detections API returned {StatusCode} at {Url}",
+					(int)httpResponseMessage.StatusCode, url);
+				return null;
 			}
 		}
 	}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -157,9 +157,10 @@ namespace AIForOrcas.Client.BL.Services
 			}
 			catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
 			{
-				// Degrade to the not-found shape rather than killing the circuit.
+				// Null means the API could not be reached, so the page can say
+				// so instead of misreporting the detection as missing.
 				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
-				return new Detection();
+				return null;
 			}
 
 			if (httpResponseMessage.IsSuccessStatusCode)
@@ -178,11 +179,12 @@ namespace AIForOrcas.Client.BL.Services
 				catch (JsonException exception)
 				{
 					_logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
-					return new Detection();
+					return null;
 				}
 			}
 			else
 			{
+				// The API answered: this id genuinely has no detection.
 				return new Detection();
 			}
 		}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -117,7 +117,21 @@ namespace AIForOrcas.Client.BL.Services
 
 			_authTokenProvider.ApplyToken(httpRequest);
 
-			var httpResponseMessage = await httpClient.SendAsync(httpRequest);
+			HttpResponseMessage httpResponseMessage;
+			try
+			{
+				httpResponseMessage = await httpClient.SendAsync(httpRequest);
+			}
+			catch (TaskCanceledException exception)
+			{
+				// A timed-out PUT surfaces as a canceled task, and Blazor drops
+				// canceled event tasks without running any catch block, so the
+				// caller would never learn the update was lost. Rethrowing as a
+				// request failure keeps the task faulted and lets callers react.
+				_logger.LogError(exception, "Timed out updating the detection at {Url}", url);
+				throw new HttpRequestException(
+					$"Failed to update detection. The request to {url} timed out.", exception);
+			}
 
 			if (!httpResponseMessage.IsSuccessStatusCode)
 			{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -176,7 +176,9 @@ namespace AIForOrcas.Client.BL.Services
 				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
 				if (string.IsNullOrWhiteSpace(responseString))
+				{
 					return new Detection();
+				}
 
 				try
 				{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -1,6 +1,7 @@
 ﻿using AIForOrcas.DTO;
 using AIForOrcas.DTO.API;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -39,10 +40,11 @@ namespace AIForOrcas.Client.BL.Services
 			{
 				httpResponseMessage = await httpClient.GetAsync(url);
 			}
-			catch (HttpRequestException exception)
+			catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
 			{
-				// An unreachable API must degrade like a failed status code; an
-				// unhandled exception here would take down the whole circuit.
+				// An unreachable or hung API must degrade like a failed status
+				// code; an unhandled exception here would take down the whole
+				// circuit.
 				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
 				return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
 			}
@@ -54,12 +56,27 @@ namespace AIForOrcas.Client.BL.Services
 				if(string.IsNullOrWhiteSpace(responseString))
 					return new PaginatedResponseDTO<List<Detection>> { Response = new List<Detection>(), TotalAmountPages = 0, TotalNumberRecords = 0 };
 
-				return new PaginatedResponseDTO<List<Detection>>
+				// The pagination headers are not guaranteed; a response without
+				// them should not kill the page.
+				httpResponseMessage.Headers.TryGetValues("totalAmountPages", out var pageValues);
+				httpResponseMessage.Headers.TryGetValues("totalNumberRecords", out var recordValues);
+				int.TryParse(pageValues?.FirstOrDefault(), out var totalAmountPages);
+				int.TryParse(recordValues?.FirstOrDefault(), out var totalNumberRecords);
+
+				try
 				{
-					Response = JsonSerializer.Deserialize<List<Detection>>(responseString, defaultJsonSerializerOptions),
-					TotalAmountPages = int.Parse(httpResponseMessage.Headers.GetValues("totalAmountPages").FirstOrDefault()),
-					TotalNumberRecords = int.Parse(httpResponseMessage.Headers.GetValues("totalNumberRecords").FirstOrDefault())
-				};
+					return new PaginatedResponseDTO<List<Detection>>
+					{
+						Response = JsonSerializer.Deserialize<List<Detection>>(responseString, defaultJsonSerializerOptions),
+						TotalAmountPages = totalAmountPages,
+						TotalNumberRecords = totalNumberRecords
+					};
+				}
+				catch (JsonException exception)
+				{
+					_logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
+					return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
+				}
 			}
 			else
 			{
@@ -124,7 +141,7 @@ namespace AIForOrcas.Client.BL.Services
 			{
 				httpResponseMessage = await httpClient.GetAsync(url);
 			}
-			catch (HttpRequestException exception)
+			catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
 			{
 				// Degrade to the not-found shape rather than killing the circuit.
 				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
@@ -135,9 +152,20 @@ namespace AIForOrcas.Client.BL.Services
 			{
 				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				var response = JsonSerializer.Deserialize<Detection>(responseString, defaultJsonSerializerOptions);
+				if (string.IsNullOrWhiteSpace(responseString))
+					return new Detection();
 
-				return response;
+				try
+				{
+					var response = JsonSerializer.Deserialize<Detection>(responseString, defaultJsonSerializerOptions);
+
+					return response ?? new Detection();
+				}
+				catch (JsonException exception)
+				{
+					_logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
+					return new Detection();
+				}
 			}
 			else
 			{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -40,7 +40,7 @@
                 <!-- Card Spectrogram Image -->
                 <div class="row">
                     <div class="col-12 px-0">
-                        <img class="img-fluid"
+                        <img class="img-fluid w-100"
                              id=@CardSpectrogramId
                              src=@Detection.SpectrogramUri />
                         <div class="card-img-overlay p-0"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -206,6 +206,10 @@
                         type="submit"
                         @onclick="(() => SubmitUpdate())"
                         disabled="@IsSubmitDisabled">
+                    @if (_submitting)
+                    {
+                        <i class="fas fa-spinner fa-spin mr-1"></i>
+                    }
                     Submit
                 </button>
             </Authorized>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -23,6 +23,9 @@ public partial class DetectionComponent
 	[Inject]
 	UserTagCache TagCache { get; set; }
 
+	[Inject]
+	IToastService ToastService { get; set; }
+
 	[Parameter]
 	public Detection Detection { get; set; }
 
@@ -244,7 +247,16 @@ public partial class DetectionComponent
 			Found = Detection.Found
 		};
 
-		await SubmitCallback.InvokeAsync(request);
+		try
+		{
+			await SubmitCallback.InvokeAsync(request);
+		}
+		catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
+		{
+			// One guard for every page that renders this component. Keep the
+			// card and the moderator's selections untouched for a retry.
+			ToastService.ShowError("The verdict was not saved because the server could not be reached. Please try again.");
+		}
 	}
 
 	private async Task ToggleCardPlayer()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -122,7 +122,7 @@ public partial class DetectionComponent
 
 		// Only initialize each detection once. This hook runs again on every
 		// parent re-render with the same Detection instance, and resetting
-		// then would wipe a verdict the moderator already selected (e.g. right
+		// then would wipe a verdict the moderator already selected (e.g., right
 		// after a failed submit shows its retry toast).
 		if (!Detection.Reviewed && !ReferenceEquals(Detection, _initializedDetection))
 		{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -7,6 +7,7 @@ public partial class DetectionComponent
 	private string _id;
 	private string _userId;
 	private Detection _initializedDetection;
+	private bool _submitting;
 	private TextInfo _ti = new CultureInfo("en-US", false).TextInfo;
 
 	[Inject]
@@ -57,7 +58,7 @@ public partial class DetectionComponent
 
 	private string AverageConfidence { get => $"{Detection.Confidence.ToString("00.##")}% average confidence"; }
 
-	private bool IsSubmitDisabled { get => string.IsNullOrWhiteSpace(Detection.Found); }
+	private bool IsSubmitDisabled { get => _submitting || string.IsNullOrWhiteSpace(Detection.Found); }
 
 	private string WasFound	{ get => _ti.ToTitleCase(Detection.Found); }
 
@@ -296,6 +297,7 @@ public partial class DetectionComponent
 			Found = Detection.Found
 		};
 
+		_submitting = true;
 		try
 		{
 			await SubmitCallback.InvokeAsync(request);
@@ -305,6 +307,10 @@ public partial class DetectionComponent
 			// One guard for every page that renders this component. Keep the
 			// card and the moderator's selections untouched for a retry.
 			ToastService.ShowError("The verdict was not saved because the server could not be reached. Please try again.");
+		}
+		finally
+		{
+			_submitting = false;
 		}
 	}
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -6,6 +6,7 @@ public partial class DetectionComponent
 {
 	private string _id;
 	private string _userId;
+	private Detection _initializedDetection;
 	private TextInfo _ti = new CultureInfo("en-US", false).TextInfo;
 
 	[Inject]
@@ -101,8 +102,13 @@ public partial class DetectionComponent
 		// TODO: Determine whether or not we should change the initial Found state
 		//       from No to something other than the three options we give the user
 
-		if (!Detection.Reviewed)
+		// Only initialize each detection once. This hook runs again on every
+		// parent re-render with the same Detection instance, and resetting
+		// then would wipe a verdict the moderator already selected (e.g. right
+		// after a failed submit shows its retry toast).
+		if (!Detection.Reviewed && !ReferenceEquals(Detection, _initializedDetection))
 		{
+			_initializedDetection = Detection;
 			Detection.Found = string.Empty;
 
 			if (string.IsNullOrEmpty(Detection.Tags))

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -303,20 +303,25 @@ public partial class DetectionComponent
 
     private async Task SubmitUpdate()
 	{
-		var request = new DetectionUpdate()
-		{
-			Id = Detection.Id,
-			Comments = Detection.Comments,
-			Tags = Detection.Tags,
-			Moderator = await AccountService.GetUsername(),
-			Moderated = DateTime.Now,
-			Reviewed = true,
-			Found = Detection.Found
-		};
-
+		// Guard before any await: a second click can be dispatched before the
+		// disabled attribute reaches the browser, and it must not enter here.
+		if (_submitting)
+			return;
 		_submitting = true;
+
 		try
 		{
+			var request = new DetectionUpdate()
+			{
+				Id = Detection.Id,
+				Comments = Detection.Comments,
+				Tags = Detection.Tags,
+				Moderator = await AccountService.GetUsername(),
+				Moderated = DateTime.Now,
+				Reviewed = true,
+				Found = Detection.Found
+			};
+
 			await SubmitCallback.InvokeAsync(request);
 		}
 		catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -306,7 +306,9 @@ public partial class DetectionComponent
 		// Guard before any await: a second click can be dispatched before the
 		// disabled attribute reaches the browser, and it must not enter here.
 		if (_submitting)
+		{
 			return;
+		}
 		_submitting = true;
 
 		try

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -327,8 +327,10 @@ public partial class DetectionComponent
 		catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
 		{
 			// One guard for every page that renders this component. Keep the
-			// card and the moderator's selections untouched for a retry.
-			ToastService.ShowError("The verdict was not saved because the server could not be reached. Please try again.");
+			// card and the moderator's selections untouched for a retry. The
+			// wording stays generic: the same exception covers an unreachable
+			// server and an error response, and the service logs the detail.
+			ToastService.ShowError("The verdict was not saved. Please try again.");
 		}
 		finally
 		{

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Extensions/Services.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Extensions/Services.cs
@@ -22,17 +22,20 @@ public static class Services
         // Register the scoped token provider that resolves the token from the active circuit.
         builder.Services.AddScoped<IAuthTokenProvider, CircuitAuthTokenProvider>();
 
-        // Register HTTP clients with handlers.
+        // Register HTTP clients with handlers. The 30s timeout keeps a hung API
+        // from pinning a page on the default 100s before it can degrade.
         builder.Services.AddHttpClient("UnauthenticatedAPI", (sp, client) =>
         {
             var apiUrl = sp.GetRequiredService<AppSettings>().APIUrl;
             client.BaseAddress = new Uri(apiUrl);
+            client.Timeout = TimeSpan.FromSeconds(30);
         });
 
         builder.Services.AddHttpClient("AuthenticatedAPI", (sp, client) =>
         {
             var apiUrl = sp.GetRequiredService<AppSettings>().APIUrl;
             client.BaseAddress = new Uri(apiUrl);
+            client.Timeout = TimeSpan.FromSeconds(30);
         });
 
         builder.Services.AddScoped<IDetectionService, DetectionService>();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
@@ -3,7 +3,11 @@
 <PageTitle>Detection - @Id</PageTitle>
 <PageHeadingComponent Title="Detection" />
 
-@if (detection == null)
+@if (isUnavailable)
+{
+	<h5 class="mt-5">An unknown error occurred while loading the record...</h5>
+}
+else if (detection == null)
 {
 	<h5 class="mt-5">Loading record...</h5>
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
@@ -23,6 +23,7 @@ public partial class SingleDetection : ComponentBase, IDisposable
 	private string _userId;
 	private Detection detection = null;
 	private bool isFound = true;
+	private bool isUnavailable = false;
 
 	protected override async Task OnInitializedAsync()
 	{
@@ -36,7 +37,8 @@ public partial class SingleDetection : ComponentBase, IDisposable
 	private async Task LoadDetection()
 	{
 		detection = await Service.GetDetectionAsync(Id);
-		if(detection.Id == null)
+		isUnavailable = detection == null;
+		if (!isUnavailable && detection.Id == null)
 			isFound = false;
 	}
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor
@@ -36,7 +36,7 @@
 </div>
 
 <BlazoredToasts Position="ToastPosition.BottomRight"
-                Timeout="2"
+                Timeout="8"
                 IconType="IconType.FontAwesome"
                 SuccessClass="success-toast-override"
                 SuccessIcon="fa fa-thumbs-up"


### PR DESCRIPTION
Fixes #575, fixes #576, fixes #577.

When the detections API goes down or hangs, the portal currently dies: list pages spin forever or the Blazor circuit is killed, and a submit during an outage silently loses the moderator's verdict. Every deploy restarts the API in place, so moderators hit this for a few minutes each time (diagnosis and repro in #575).

What changes:

- List pages (Candidates, Unknown, Confirmed, False Positives) catch the failed call, log it, and show the existing "unknown error" message instead of killing the circuit. Navigation keeps working and the next successful load recovers.
- API calls time out at 30 seconds instead of hanging past the 100-second circuit kill. A failed or timed-out submit shows an error toast, and the verdict, tags and comment stay selected so the moderator can retry.
- The Submit button disables with a spinner while the request is in flight, and the error toast stays up 8 seconds instead of 2 (global toast timeout; Blazored.Toast 3.2.2 has no per-toast setting).
- The detail page tells an unreachable API apart from a record that doesn't exist, instead of claiming "could not be found" during an outage.

Two changes go past the literal issue text and are worth flagging. Verdicts were also being wiped by parent re-renders, so each detection now initializes once and a failed submit keeps the selection for retry. And the card spectrogram no longer jumps to full width when Play is hit on wide screens; it renders at column width from the start.

## How to test

Run the portal against a local API. To simulate an outage, stop the API (connection refused). To simulate a hang, pause the API process instead, `docker pause <api container>` or `kill -STOP <pid>`, so connections open but never get answered. The two behave differently in HttpClient, which is why both are worth checking.

1. **Queue during an outage.** Stop the API, load Candidates. The page should show "An unknown error occurred while loading records" with the navigation still working, no reconnect bar. Before this change it spins on "Loading records..." until the circuit dies.
2. **Recovery.** Start the API again, navigate away and back. Records load, no browser refresh needed.
3. **Hung load.** Pause the API, load Candidates. After 30 seconds the same error message appears. Before this change the page hangs about 100 seconds and then kills the circuit.
4. **Submit during an outage.** With the API up, pick a candidate and select a verdict, a tag and a comment. Stop the API, hit Submit. An error toast appears and every selection stays in place. Start the API, submit again, it goes through. Before this change the selections were lost and the circuit died.
5. **Hung submit.** Same setup, but pause the API instead. Submit disables with a spinner, and after 30 seconds the same toast appears with selections kept. Before this change there was no feedback at all.
6. **Other list views.** Stop the API and visit Unknown, Confirmed and False Positives. Each degrades with the message.
7. **Detail page.** Open a detection's detail page, stop the API, reload. It reports an unknown error rather than "could not be found", and loads again once the API is back.
8. **Spectrogram width** (needs a window wider than ~2900px, or zoom out). On Candidates the spectrogram fills its column before Play and doesn't resize when playback starts.

## Notes for the reviewer

A few scope notes. The 30 second timeout sits on the two named HttpClients, so the tag and metrics services share it, but their pages (Dashboard, Tags, User Activity) aren't hardened here and still fail hard when the API is down; that's follow-up material. The toast timeout is global, so success toasts also stay up 8 seconds now, since Blazored.Toast 3.2.2 has no per-toast setting; if that reads as too long, the alternative is a package upgrade. And while in the fetch path: an empty or null JSON body from a detection fetch used to throw a NullReferenceException, it now maps to not found.
