### PR TITLE
Removed rendering stale pagination buttons  after last verdict

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -42,6 +42,7 @@ public partial class Candidates : IDisposable
 	private async Task LoadDetections()
 	{
 		loadStatus = "Loading records...";
+		detections = null;
 		var paginatedResponse = await Service.GetCandidateDetectionsAsync(paginationOptions, filterOptions);
 
 		pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
@@ -76,7 +77,6 @@ public partial class Candidates : IDisposable
 	private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
 	{
 		paginationOptions = returnedPaginationOptions;
-		detections = null;
 		await LoadDetections();
 		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
 		StateHasChanged();
@@ -86,7 +86,6 @@ public partial class Candidates : IDisposable
 	{
 		filterOptions = returnedFilterOptions;
 		paginationOptions.Page = 1;
-		detections = null;
 		await LoadDetections();
 		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
 		StateHasChanged();


### PR DESCRIPTION
Fixes #605 

## Root cause
`ActOnSubmitCallback` never cleared `detections` before reloading, unlike the other two callbacks. The pager is gated on `detections != null`, so it kept rendering.

## Fix
Clear `detections` at the top of `LoadDetections()` itself, so every caller gets it consistently. Removed the now-redundant clears from the other two callbacks.