### PR TITLE
Add .editorconfig and normalize whitespace/style in ModeratorFrontEnd

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+
+[*.cs]
+indent_size                                                = 4
+dotnet_style_predefined_type_for_locals_parameters_members = true : warning
+csharp_new_line_before_open_brace                          = all
+csharp_space_after_keywords_in_control_flow_statements     = true
+
+[*.razor]
+indent_size  = 4
+

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/DateHelper.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/DateHelper.cs
@@ -2,26 +2,26 @@
 
 namespace AIForOrcas.Client.BL.Helpers
 {
-	public static class DateHelper
-	{
-		public static string UTCToPDT(DateTime datetime, bool timeOnly = false)
-		{
-			TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-			datetime = DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
-			DateTime pstTime = TimeZoneInfo.ConvertTime(datetime, TimeZoneInfo.Utc, pst);
-			var zoneString = pst.IsDaylightSavingTime(pstTime) ? "PDT" : "PST";
-			var format = timeOnly ? $"HH:mm:ss" : $"dd MMM HH:mm:ss '{zoneString}'";
+    public static class DateHelper
+    {
+        public static string UTCToPDT(DateTime datetime, bool timeOnly = false)
+        {
+            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            datetime = DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
+            DateTime pstTime = TimeZoneInfo.ConvertTime(datetime, TimeZoneInfo.Utc, pst);
+            var zoneString = pst.IsDaylightSavingTime(pstTime) ? "PDT" : "PST";
+            var format = timeOnly ? $"HH:mm:ss" : $"dd MMM HH:mm:ss '{zoneString}'";
             return $"{pstTime.ToString(format)}";
         }
 
-		public static string UTCToPDTFull(DateTime datetime)
-		{
-			TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-			datetime = DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
-			DateTime pstTime = TimeZoneInfo.ConvertTime(datetime, TimeZoneInfo.Utc, pst);
-			var zoneString = pst.IsDaylightSavingTime(pstTime) ? "PDT" : "PST";
-			var format = $"dd MMM yyyy HH:mm:ss '{zoneString}'";
-			return $"{pstTime.ToString(format)}";
-		}
-	}
+        public static string UTCToPDTFull(DateTime datetime)
+        {
+            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            datetime = DateTime.SpecifyKind(datetime, DateTimeKind.Utc);
+            DateTime pstTime = TimeZoneInfo.ConvertTime(datetime, TimeZoneInfo.Utc, pst);
+            var zoneString = pst.IsDaylightSavingTime(pstTime) ? "PDT" : "PST";
+            var format = $"dd MMM yyyy HH:mm:ss '{zoneString}'";
+            return $"{pstTime.ToString(format)}";
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/EmailHelper.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/EmailHelper.cs
@@ -1,21 +1,21 @@
 ﻿namespace AIForOrcas.Client.BL.Helpers
 {
-	public static class EmailHelper
-	{
-		public static string ExtractName(string email)
-		{
+    public static class EmailHelper
+    {
+        public static string ExtractName(string email)
+        {
             if (string.IsNullOrEmpty(email) ||
                 (!email.Contains("@") && !email.Contains("#")))
                 return email;
 
-			var working = email;
-			if (working.Contains("@"))
-				working = working.Split('@')[0];
+            var working = email;
+            if (working.Contains("@"))
+                working = working.Split('@')[0];
 
-			if (working.Contains("#"))
-				working = working.Split('#')[1];
+            if (working.Contains("#"))
+                working = working.Split('#')[1];
 
-			return working;
-		}
-	}
+            return working;
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/AuthTokenProviderExtensions.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/AuthTokenProviderExtensions.cs
@@ -3,13 +3,13 @@ using System.Net.Http.Headers;
 
 namespace AIForOrcas.Client.BL.Services
 {
-	public static class AuthTokenProviderExtensions
-	{
-		public static void ApplyToken(this IAuthTokenProvider provider, HttpRequestMessage request)
-		{
-			var token = provider.GetToken();
-			if (!string.IsNullOrWhiteSpace(token))
-				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-		}
-	}
+    public static class AuthTokenProviderExtensions
+    {
+        public static void ApplyToken(this IAuthTokenProvider provider, HttpRequestMessage request)
+        {
+            var token = provider.GetToken();
+            if (!string.IsNullOrWhiteSpace(token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -11,200 +11,200 @@ using System.Threading.Tasks;
 
 namespace AIForOrcas.Client.BL.Services
 {
-	public class DetectionService : IDetectionService
-	{
-		private string api = "api/detections";
-		private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
-		private readonly IHttpClientFactory _httpClientFactory;
-		private readonly IAuthTokenProvider _authTokenProvider;
-		private readonly ILogger<DetectionService> _logger;
+    public class DetectionService : IDetectionService
+    {
+        private string api = "api/detections";
+        private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IAuthTokenProvider _authTokenProvider;
+        private readonly ILogger<DetectionService> _logger;
 
-		public DetectionService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider, ILogger<DetectionService> logger)
-		{
-			_httpClientFactory = httpClientFactory;
-			_authTokenProvider = authTokenProvider;
-			_logger = logger;
-		}
+        public DetectionService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider, ILogger<DetectionService> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _authTokenProvider = authTokenProvider;
+            _logger = logger;
+        }
 
-		// Get detections based on passed view, pagination options, and filter options
-		private async Task<PaginatedResponseDTO<List<Detection>>> GetDetectionsAsync(string viewName, PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
-		{
-			var prefix = api.Contains("?") ? $"{api}/{viewName}&" : $"{api}/{viewName}?";
-			var url = $"{prefix}{paginationOptions.QueryString}&{filterOptions.QueryString}";
+        // Get detections based on passed view, pagination options, and filter options
+        private async Task<PaginatedResponseDTO<List<Detection>>> GetDetectionsAsync(string viewName, PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
+        {
+            var prefix = api.Contains("?") ? $"{api}/{viewName}&" : $"{api}/{viewName}?";
+            var url = $"{prefix}{paginationOptions.QueryString}&{filterOptions.QueryString}";
 
-			// Create client on-demand from the current scope.
-			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
+            // Create client on-demand from the current scope.
+            var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
 
-			HttpResponseMessage httpResponseMessage;
-			try
-			{
-				httpResponseMessage = await httpClient.GetAsync(url);
-			}
-			catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
-			{
-				// An unreachable or hung API must degrade like a failed status
-				// code; an unhandled exception here would take down the whole
-				// circuit.
-				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
-				return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
-			}
+            HttpResponseMessage httpResponseMessage;
+            try
+            {
+                httpResponseMessage = await httpClient.GetAsync(url);
+            }
+            catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
+            {
+                // An unreachable or hung API must degrade like a failed status
+                // code; an unhandled exception here would take down the whole
+                // circuit.
+                _logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
+                return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
+            }
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if(string.IsNullOrWhiteSpace(responseString))
-					return new PaginatedResponseDTO<List<Detection>> { Response = new List<Detection>(), TotalAmountPages = 0, TotalNumberRecords = 0 };
+                if (string.IsNullOrWhiteSpace(responseString))
+                    return new PaginatedResponseDTO<List<Detection>> { Response = new List<Detection>(), TotalAmountPages = 0, TotalNumberRecords = 0 };
 
-				// The pagination headers are not guaranteed; a response without
-				// them should not kill the page.
-				httpResponseMessage.Headers.TryGetValues("totalAmountPages", out var pageValues);
-				httpResponseMessage.Headers.TryGetValues("totalNumberRecords", out var recordValues);
-				int.TryParse(pageValues?.FirstOrDefault(), out var totalAmountPages);
-				int.TryParse(recordValues?.FirstOrDefault(), out var totalNumberRecords);
+                // The pagination headers are not guaranteed; a response without
+                // them should not kill the page.
+                httpResponseMessage.Headers.TryGetValues("totalAmountPages", out var pageValues);
+                httpResponseMessage.Headers.TryGetValues("totalNumberRecords", out var recordValues);
+                int.TryParse(pageValues?.FirstOrDefault(), out var totalAmountPages);
+                int.TryParse(recordValues?.FirstOrDefault(), out var totalNumberRecords);
 
-				try
-				{
-					return new PaginatedResponseDTO<List<Detection>>
-					{
-						Response = JsonSerializer.Deserialize<List<Detection>>(responseString, defaultJsonSerializerOptions),
-						TotalAmountPages = totalAmountPages,
-						TotalNumberRecords = totalNumberRecords
-					};
-				}
-				catch (JsonException exception)
-				{
-					_logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
-					return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
-				}
-			}
-			else
-			{
-				return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
-			}
+                try
+                {
+                    return new PaginatedResponseDTO<List<Detection>>
+                    {
+                        Response = JsonSerializer.Deserialize<List<Detection>>(responseString, defaultJsonSerializerOptions),
+                        TotalAmountPages = totalAmountPages,
+                        TotalNumberRecords = totalNumberRecords
+                    };
+                }
+                catch (JsonException exception)
+                {
+                    _logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
+                    return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
+                }
+            }
+            else
+            {
+                return new PaginatedResponseDTO<List<Detection>> { Response = null, TotalAmountPages = 0, TotalNumberRecords = 0 };
+            }
 
-		}
+        }
 
-		// Get unreviewed detections
-		public async Task<PaginatedResponseDTO<List<Detection>>> GetCandidateDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
-		{
-			return await GetDetectionsAsync("unreviewed", paginationOptions, filterOptions);
-		}
+        // Get unreviewed detections
+        public async Task<PaginatedResponseDTO<List<Detection>>> GetCandidateDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
+        {
+            return await GetDetectionsAsync("unreviewed", paginationOptions, filterOptions);
+        }
 
-		public async Task<PaginatedResponseDTO<List<Detection>>> GetConfirmedDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
-		{
-			return await GetDetectionsAsync("confirmed", paginationOptions, filterOptions);
-		}
+        public async Task<PaginatedResponseDTO<List<Detection>>> GetConfirmedDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
+        {
+            return await GetDetectionsAsync("confirmed", paginationOptions, filterOptions);
+        }
 
-		public async Task<PaginatedResponseDTO<List<Detection>>> GetFalseDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
-		{
-			return await GetDetectionsAsync("falsepositives", paginationOptions, filterOptions);
-		}
+        public async Task<PaginatedResponseDTO<List<Detection>>> GetFalseDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
+        {
+            return await GetDetectionsAsync("falsepositives", paginationOptions, filterOptions);
+        }
 
-		public async Task<PaginatedResponseDTO<List<Detection>>> GetUnconfirmedDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
-		{
-			return await GetDetectionsAsync("unknowns", paginationOptions, filterOptions);
-		}
+        public async Task<PaginatedResponseDTO<List<Detection>>> GetUnconfirmedDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions)
+        {
+            return await GetDetectionsAsync("unknowns", paginationOptions, filterOptions);
+        }
 
-		public async Task UpdateRequestAsync(DetectionUpdate request)
-		{
-			var url = $"{api}/{request.Id}";
-			var dataJson = JsonSerializer.Serialize(request);
-			var stringContent = new StringContent(dataJson, Encoding.UTF8, "application/json");
+        public async Task UpdateRequestAsync(DetectionUpdate request)
+        {
+            var url = $"{api}/{request.Id}";
+            var dataJson = JsonSerializer.Serialize(request);
+            var stringContent = new StringContent(dataJson, Encoding.UTF8, "application/json");
 
-			var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
-			var httpRequest = new HttpRequestMessage(HttpMethod.Put, url) { Content = stringContent };
+            var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
+            var httpRequest = new HttpRequestMessage(HttpMethod.Put, url) { Content = stringContent };
 
-			_authTokenProvider.ApplyToken(httpRequest);
+            _authTokenProvider.ApplyToken(httpRequest);
 
-			HttpResponseMessage httpResponseMessage;
-			try
-			{
-				httpResponseMessage = await httpClient.SendAsync(httpRequest);
-			}
-			catch (TaskCanceledException exception)
-			{
-				// A timed-out PUT surfaces as a canceled task. Rethrow it as a
-				// request failure so callers handle one exception type for "the
-				// update was lost", whether the API refused or timed out.
-				_logger.LogError(exception, "Timed out updating the detection at {Url}", url);
-				throw new HttpRequestException(
-					$"Failed to update detection. The request to {url} timed out.", exception);
-			}
-			catch (HttpRequestException exception)
-			{
-				// The UI suppresses this into a toast, so log it here or the
-				// failure never reaches the server diagnostics.
-				_logger.LogError(exception, "Unable to reach the detections API to update at {Url}", url);
-				throw;
-			}
+            HttpResponseMessage httpResponseMessage;
+            try
+            {
+                httpResponseMessage = await httpClient.SendAsync(httpRequest);
+            }
+            catch (TaskCanceledException exception)
+            {
+                // A timed-out PUT surfaces as a canceled task. Rethrow it as a
+                // request failure so callers handle one exception type for "the
+                // update was lost", whether the API refused or timed out.
+                _logger.LogError(exception, "Timed out updating the detection at {Url}", url);
+                throw new HttpRequestException(
+                    $"Failed to update detection. The request to {url} timed out.", exception);
+            }
+            catch (HttpRequestException exception)
+            {
+                // The UI suppresses this into a toast, so log it here or the
+                // failure never reaches the server diagnostics.
+                _logger.LogError(exception, "Unable to reach the detections API to update at {Url}", url);
+                throw;
+            }
 
-			if (!httpResponseMessage.IsSuccessStatusCode)
-			{
-				var errorContent = await httpResponseMessage.Content.ReadAsStringAsync();
-				var statusCode = (int)httpResponseMessage.StatusCode;
+            if (!httpResponseMessage.IsSuccessStatusCode)
+            {
+                var errorContent = await httpResponseMessage.Content.ReadAsStringAsync();
+                var statusCode = (int)httpResponseMessage.StatusCode;
 
-				_logger.LogError("The detections API rejected the update at {Url} with {StatusCode}: {Details}",
-					url, statusCode, errorContent);
-				throw new HttpRequestException(
-					$"Failed to update detection. Status: {statusCode} {httpResponseMessage.ReasonPhrase}. Details: {errorContent}");
-			}
-		}
+                _logger.LogError("The detections API rejected the update at {Url} with {StatusCode}: {Details}",
+                    url, statusCode, errorContent);
+                throw new HttpRequestException(
+                    $"Failed to update detection. Status: {statusCode} {httpResponseMessage.ReasonPhrase}. Details: {errorContent}");
+            }
+        }
 
-		public async Task<Detection> GetDetectionAsync(string id)
-		{
-			var url = $"{api}/{id}";
+        public async Task<Detection> GetDetectionAsync(string id)
+        {
+            var url = $"{api}/{id}";
 
-			// Create client on-demand from the current scope.
-			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
+            // Create client on-demand from the current scope.
+            var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
 
-			HttpResponseMessage httpResponseMessage;
-			try
-			{
-				httpResponseMessage = await httpClient.GetAsync(url);
-			}
-			catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
-			{
-				// Null means the API could not be reached, so the page can say
-				// so instead of misreporting the detection as missing.
-				_logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
-				return null;
-			}
+            HttpResponseMessage httpResponseMessage;
+            try
+            {
+                httpResponseMessage = await httpClient.GetAsync(url);
+            }
+            catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
+            {
+                // Null means the API could not be reached, so the page can say
+                // so instead of misreporting the detection as missing.
+                _logger.LogError(exception, "Unable to reach the detections API at {Url}", url);
+                return null;
+            }
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (string.IsNullOrWhiteSpace(responseString))
-				{
-					return new Detection();
-				}
+                if (string.IsNullOrWhiteSpace(responseString))
+                {
+                    return new Detection();
+                }
 
-				try
-				{
-					var response = JsonSerializer.Deserialize<Detection>(responseString, defaultJsonSerializerOptions);
+                try
+                {
+                    var response = JsonSerializer.Deserialize<Detection>(responseString, defaultJsonSerializerOptions);
 
-					return response ?? new Detection();
-				}
-				catch (JsonException exception)
-				{
-					_logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
-					return null;
-				}
-			}
-			else if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NotFound)
-			{
-				// The API answered 404: this id genuinely has no detection.
-				return new Detection();
-			}
-			else
-			{
-				// Any other error status is the API failing, not a missing
-				// record; report it like an unreachable API.
-				_logger.LogError("The detections API returned {StatusCode} at {Url}",
-					(int)httpResponseMessage.StatusCode, url);
-				return null;
-			}
-		}
-	}
+                    return response ?? new Detection();
+                }
+                catch (JsonException exception)
+                {
+                    _logger.LogError(exception, "Malformed response from the detections API at {Url}", url);
+                    return null;
+                }
+            }
+            else if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // The API answered 404: this id genuinely has no detection.
+                return new Detection();
+            }
+            else
+            {
+                // Any other error status is the API failing, not a missing
+                // record; report it like an unreachable API.
+                _logger.LogError("The detections API returned {StatusCode} at {Url}",
+                    (int)httpResponseMessage.StatusCode, url);
+                return null;
+            }
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IAuthTokenProvider.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IAuthTokenProvider.cs
@@ -1,7 +1,7 @@
 namespace AIForOrcas.Client.BL.Services
 {
-	public interface IAuthTokenProvider
-	{
-		string GetToken();
-	}
+    public interface IAuthTokenProvider
+    {
+        string GetToken();
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IDetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IDetectionService.cs
@@ -5,14 +5,14 @@ using System.Threading.Tasks;
 
 namespace AIForOrcas.Client.BL.Services
 {
-	public interface IDetectionService
-	{
-		Task<PaginatedResponseDTO<List<Detection>>> GetCandidateDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions);
-		Task<PaginatedResponseDTO<List<Detection>>> GetConfirmedDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
-		Task<PaginatedResponseDTO<List<Detection>>> GetUnconfirmedDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
-		Task<PaginatedResponseDTO<List<Detection>>> GetFalseDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
+    public interface IDetectionService
+    {
+        Task<PaginatedResponseDTO<List<Detection>>> GetCandidateDetectionsAsync(PaginationOptionsDTO paginationOptions, IFilterOptions filterOptions);
+        Task<PaginatedResponseDTO<List<Detection>>> GetConfirmedDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
+        Task<PaginatedResponseDTO<List<Detection>>> GetUnconfirmedDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
+        Task<PaginatedResponseDTO<List<Detection>>> GetFalseDetectionsAsync(PaginationOptionsDTO pagination, IFilterOptions filterOptions);
 
-		Task<Detection> GetDetectionAsync(string id);
-		Task UpdateRequestAsync(DetectionUpdate request);
-	}
+        Task<Detection> GetDetectionAsync(string id);
+        Task UpdateRequestAsync(DetectionUpdate request);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IMetricsService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/IMetricsService.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 
 namespace AIForOrcas.Client.BL.Services
 {
-	public interface IMetricsService
-	{
+    public interface IMetricsService
+    {
 
-		Task<Metrics> GetSiteMetricsAsync(IFilterOptions filterOptions);
-		Task<ModeratorMetrics> GetModeratorMetricsAsync(IFilterOptions filterOptions);
-	}
+        Task<Metrics> GetSiteMetricsAsync(IFilterOptions filterOptions);
+        Task<ModeratorMetrics> GetModeratorMetricsAsync(IFilterOptions filterOptions);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/MetricsService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/MetricsService.cs
@@ -6,67 +6,67 @@ using System.Threading.Tasks;
 
 namespace AIForOrcas.Client.BL.Services
 {
-	public class MetricsService : IMetricsService
-	{
-		private readonly IHttpClientFactory _httpClientFactory;
-		private string api = "api/metrics";
-		private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+    public class MetricsService : IMetricsService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private string api = "api/metrics";
+        private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
 
-		public MetricsService(IHttpClientFactory httpClientFactory)
-		{
-			_httpClientFactory = httpClientFactory;
-		}
+        public MetricsService(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
 
-		public async Task<ModeratorMetrics> GetModeratorMetricsAsync(IFilterOptions filterOptions)
-		{
-			var prefix = api.Contains("?") ? $"{api}/moderator&" : $"{api}/moderator?";
-			var url = $"{prefix}{filterOptions.QueryString}";
+        public async Task<ModeratorMetrics> GetModeratorMetricsAsync(IFilterOptions filterOptions)
+        {
+            var prefix = api.Contains("?") ? $"{api}/moderator&" : $"{api}/moderator?";
+            var url = $"{prefix}{filterOptions.QueryString}";
 
-			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
-			var httpResponseMessage = await httpClient.GetAsync(url);
+            var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
+            var httpResponseMessage = await httpClient.GetAsync(url);
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
-					return new ModeratorMetrics() { HasContent = false };
+                if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
+                    return new ModeratorMetrics() { HasContent = false };
 
-				var response = JsonSerializer.Deserialize<ModeratorMetrics>(responseString, defaultJsonSerializerOptions);
-				response.HasContent = true;
+                var response = JsonSerializer.Deserialize<ModeratorMetrics>(responseString, defaultJsonSerializerOptions);
+                response.HasContent = true;
 
-				return response;
-			}
-			else
-			{
-				return new ModeratorMetrics() { HasContent = false };
-			}
-		}
+                return response;
+            }
+            else
+            {
+                return new ModeratorMetrics() { HasContent = false };
+            }
+        }
 
-		public async Task<Metrics> GetSiteMetricsAsync(IFilterOptions filterOptions)
-		{
-			var prefix = api.Contains("?") ? $"{api}/system&" : $"{api}/system?";
-			var url = $"{prefix}{filterOptions.QueryString}";
+        public async Task<Metrics> GetSiteMetricsAsync(IFilterOptions filterOptions)
+        {
+            var prefix = api.Contains("?") ? $"{api}/system&" : $"{api}/system?";
+            var url = $"{prefix}{filterOptions.QueryString}";
 
-			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
-			var httpResponseMessage = await httpClient.GetAsync(url);
+            var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
+            var httpResponseMessage = await httpClient.GetAsync(url);
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
-					return new Metrics() { HasContent = false };
+                if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
+                    return new Metrics() { HasContent = false };
 
-				var response = JsonSerializer.Deserialize<Metrics>(responseString, defaultJsonSerializerOptions);
-				response.HasContent = true;
+                var response = JsonSerializer.Deserialize<Metrics>(responseString, defaultJsonSerializerOptions);
+                response.HasContent = true;
 
-				return response;
-			}
-			else
-			{
-				return new Metrics() { HasContent = false };
-			}
-		}
-	}
+                return response;
+            }
+            else
+            {
+                return new Metrics() { HasContent = false };
+            }
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/TagService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/TagService.cs
@@ -11,92 +11,92 @@ namespace AIForOrcas.Client.BL.Services
 {
     public class TagService : ITagService
     {
-		private readonly IHttpClientFactory _httpClientFactory;
-		private readonly IAuthTokenProvider _authTokenProvider;
-		private string api = "api/tags";
-		private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IAuthTokenProvider _authTokenProvider;
+        private string api = "api/tags";
+        private JsonSerializerOptions defaultJsonSerializerOptions => new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
 
-		public TagService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider)
-		{
-			_httpClientFactory = httpClientFactory;
-			_authTokenProvider = authTokenProvider;
-		}
+        public TagService(IHttpClientFactory httpClientFactory, IAuthTokenProvider authTokenProvider)
+        {
+            _httpClientFactory = httpClientFactory;
+            _authTokenProvider = authTokenProvider;
+        }
 
-		// Get the list of unique tags
-		public async Task<List<string>> GetUniqueTagsAsync()
-		{
-			var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
-			var httpResponseMessage = await httpClient.GetAsync(api);
+        // Get the list of unique tags
+        public async Task<List<string>> GetUniqueTagsAsync()
+        {
+            var httpClient = _httpClientFactory.CreateClient("UnauthenticatedAPI");
+            var httpResponseMessage = await httpClient.GetAsync(api);
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (string.IsNullOrWhiteSpace(responseString))
-					return new List<string>();
+                if (string.IsNullOrWhiteSpace(responseString))
+                    return new List<string>();
 
-				return JsonSerializer.Deserialize<List<string>>(responseString, defaultJsonSerializerOptions);
-			}
-			else
-			{
-				return new List<string>();
-			}
-		}
+                return JsonSerializer.Deserialize<List<string>>(responseString, defaultJsonSerializerOptions);
+            }
+            else
+            {
+                return new List<string>();
+            }
+        }
 
-		// replace the current tag with a new one
-		public async Task<int> UpdateTagAsync(TagUpdate payload)
-		{
-			var dataJson = JsonSerializer.Serialize(payload);
-			var stringContent = new StringContent(dataJson, Encoding.UTF8, "application/json");
+        // replace the current tag with a new one
+        public async Task<int> UpdateTagAsync(TagUpdate payload)
+        {
+            var dataJson = JsonSerializer.Serialize(payload);
+            var stringContent = new StringContent(dataJson, Encoding.UTF8, "application/json");
 
-			var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
-			var httpRequest = new HttpRequestMessage(HttpMethod.Put, api) { Content = stringContent };
+            var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
+            var httpRequest = new HttpRequestMessage(HttpMethod.Put, api) { Content = stringContent };
 
-			_authTokenProvider.ApplyToken(httpRequest);
+            _authTokenProvider.ApplyToken(httpRequest);
 
-			var httpResponseMessage = await httpClient.SendAsync(httpRequest);
+            var httpResponseMessage = await httpClient.SendAsync(httpRequest);
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (string.IsNullOrWhiteSpace(responseString))
-					return 0;
+                if (string.IsNullOrWhiteSpace(responseString))
+                    return 0;
 
-				return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
-			}
-			else
-			{
-				return 0;
-			}
-		}
+                return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
+            }
+            else
+            {
+                return 0;
+            }
+        }
 
-		// delete a tag completely from the database
-		public async Task<int> DeleteTagAsync(string tag)
-		{
-			var url = $"{api}?tag={HttpUtility.UrlEncode(tag)}";
+        // delete a tag completely from the database
+        public async Task<int> DeleteTagAsync(string tag)
+        {
+            var url = $"{api}?tag={HttpUtility.UrlEncode(tag)}";
 
-			var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
-			var httpRequest = new HttpRequestMessage(HttpMethod.Delete, url);
+            var httpClient = _httpClientFactory.CreateClient("AuthenticatedAPI");
+            var httpRequest = new HttpRequestMessage(HttpMethod.Delete, url);
 
-			_authTokenProvider.ApplyToken(httpRequest);
+            _authTokenProvider.ApplyToken(httpRequest);
 
-			var httpResponseMessage = await httpClient.SendAsync(httpRequest);
+            var httpResponseMessage = await httpClient.SendAsync(httpRequest);
 
-			if (httpResponseMessage.IsSuccessStatusCode)
-			{
-				var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
-				if (string.IsNullOrWhiteSpace(responseString))
-					return 0;
+                if (string.IsNullOrWhiteSpace(responseString))
+                    return 0;
 
-				return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
-			}
-			else
-			{
-				return 0;
-			}
-		}
+                return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
+            }
+            else
+            {
+                return 0;
+            }
+        }
 
-	}
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/App.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/App.razor
@@ -1,12 +1,12 @@
 ﻿<CascadingAuthenticationState>
-	<Router AppAssembly="@typeof(Program).Assembly">
-		<Found Context="routeData">
-			<AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-		</Found>
-		<NotFound>
-			<LayoutView Layout="@typeof(MainLayout)">
-				<p>Sorry, there's nothing at this address.</p>
-			</LayoutView>
-		</NotFound>
-	</Router>
+    <Router AppAssembly="@typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
 </CascadingAuthenticationState>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/CandidateFilterComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/CandidateFilterComponent.razor
@@ -1,39 +1,39 @@
 ﻿<EditForm Model="FilterOptions" class="container-fluid px-0 mb-2">
-	<div class="row">
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Sort By:</label>
-				<InputSelect id="sortBy" class="form-control" @bind-Value="FilterOptions.SortBy">
-					<option value="confidence">Confidence</option>
-					<option value="timestamp">Timestamp</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Sort Order:</label>
-				<InputSelect id="sortOrder" class="form-control" @bind-Value="FilterOptions.SortOrder">
-					<option value="desc">Descending</option>
-					<option value="asc">Ascending</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Timeframe:</label>
-				<InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
-					<option value="30m">Last 30 Minutes</option>
-					<option value="3h">Last 3 Hours</option>
-					<option value="6h">Last 6 Hours</option>
-					<option value="24h">Last 24 Hours</option>
-					<option value="1w">Last Week</option>
-					<option value="1m">Last Month</option>
-					<option value="all">All</option>
-					<option value="range">Select Date Range</option>
-				</InputSelect>
-			</div>
-		</div>
-		 @if(FilterOptions.Timeframe=="range")
+    <div class="row">
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Sort By:</label>
+                <InputSelect id="sortBy" class="form-control" @bind-Value="FilterOptions.SortBy">
+                    <option value="confidence">Confidence</option>
+                    <option value="timestamp">Timestamp</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Sort Order:</label>
+                <InputSelect id="sortOrder" class="form-control" @bind-Value="FilterOptions.SortOrder">
+                    <option value="desc">Descending</option>
+                    <option value="asc">Ascending</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Timeframe:</label>
+                <InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
+                    <option value="30m">Last 30 Minutes</option>
+                    <option value="3h">Last 3 Hours</option>
+                    <option value="6h">Last 6 Hours</option>
+                    <option value="24h">Last 24 Hours</option>
+                    <option value="1w">Last Week</option>
+                    <option value="1m">Last Month</option>
+                    <option value="all">All</option>
+                    <option value="range">Select Date Range</option>
+                </InputSelect>
+            </div>
+        </div>
+         @if(FilterOptions.Timeframe=="range")
         {
         <div class="col-12 col-md-2 col-lg-2">
             <div class="form-group mb-0">
@@ -50,21 +50,21 @@
             </div>
         </div>
         }
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Location:</label>
-				<InputSelect id="location" class="form-control" @bind-Value="SelectedLocation">
-					@foreach (var location in AllLocations)
-					{
-						<option value="@location">@location</option>
-					}
-					<option value="all">All</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-lg-2 col-md-2 mt-1 mt-lg-0 pt-lg-4">
-			<button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
-		</div>
-	</div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Location:</label>
+                <InputSelect id="location" class="form-control" @bind-Value="SelectedLocation">
+                    @foreach (var location in AllLocations)
+                    {
+                        <option value="@location">@location</option>
+                    }
+                    <option value="all">All</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-lg-2 col-md-2 mt-1 mt-lg-0 pt-lg-4">
+            <button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
+        </div>
+    </div>
 </EditForm>
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/CandidateFilterComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/CandidateFilterComponent.razor.cs
@@ -2,55 +2,55 @@
 
 public partial class CandidateFilterComponent
 {
-	[Parameter]
-	public CandidateFilterOptionsDTO FilterOptions { get; set; } = new CandidateFilterOptionsDTO();
+    [Parameter]
+    public CandidateFilterOptionsDTO FilterOptions { get; set; } = new CandidateFilterOptionsDTO();
 
-	[Parameter]
-	public EventCallback<CandidateFilterOptionsDTO> ApplyFilterCallback { get; set; }
+    [Parameter]
+    public EventCallback<CandidateFilterOptionsDTO> ApplyFilterCallback { get; set; }
 
-	[Inject]
-	public AppSettings AppSettings { get; set; }
+    [Inject]
+    public AppSettings AppSettings { get; set; }
 
-	private List<string> AllLocations = new List<string>();
+    private List<string> AllLocations = new List<string>();
 
-	// Local UI-only tracking of selected location.
-	private string SelectedLocation { get; set; } = "all";
+    // Local UI-only tracking of selected location.
+    private string SelectedLocation { get; set; } = "all";
 
-	protected override void OnInitialized()
-	{
-		AllLocations = HydrophoneLocations.Locations.ToList();
-		// Don't initialize from FilterOptions.Location - keep it independent.
-		SelectedLocation = "all";
-	}
+    protected override void OnInitialized()
+    {
+        AllLocations = HydrophoneLocations.Locations.ToList();
+        // Don't initialize from FilterOptions.Location - keep it independent.
+        SelectedLocation = "all";
+    }
 
-	private async Task ApplyFilter()
-	{
-		// The HydrophoneId (e.g., rpi_orcasound_lab) is constant whereas the Location
-		// value can and has changed over time (e.g., Haro Strait vs Orcasound Lab).
-		// The UI lets the user choose among labels that are Location values, but
-		// we want to actually query by HydrophoneId.
+    private async Task ApplyFilter()
+    {
+        // The HydrophoneId (e.g., rpi_orcasound_lab) is constant whereas the Location
+        // value can and has changed over time (e.g., Haro Strait vs Orcasound Lab).
+        // The UI lets the user choose among labels that are Location values, but
+        // we want to actually query by HydrophoneId.
 
-		// Always set location to "all" so backend doesn't filter by location name.
-		FilterOptions.Location = "all";
+        // Always set location to "all" so backend doesn't filter by location name.
+        FilterOptions.Location = "all";
 
-		if (SelectedLocation != "all")
-		{
-			var hydrophoneId = HydrophoneLocations.GetIdByLocation(SelectedLocation);
-			if (hydrophoneId != null)
-			{
-				FilterOptions.HydrophoneId = hydrophoneId;
-			}
-			else
-			{
-				// Location not found in map, default to "all".
-				FilterOptions.HydrophoneId = "all";
-			}
-		}
-		else
-		{
-			FilterOptions.HydrophoneId = "all";
-		}
+        if (SelectedLocation != "all")
+        {
+            var hydrophoneId = HydrophoneLocations.GetIdByLocation(SelectedLocation);
+            if (hydrophoneId != null)
+            {
+                FilterOptions.HydrophoneId = hydrophoneId;
+            }
+            else
+            {
+                // Location not found in map, default to "all".
+                FilterOptions.HydrophoneId = "all";
+            }
+        }
+        else
+        {
+            FilterOptions.HydrophoneId = "all";
+        }
 
-		await ApplyFilterCallback.InvokeAsync(FilterOptions);
-	}
+        await ApplyFilterCallback.InvokeAsync(FilterOptions);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -4,283 +4,283 @@ namespace AIForOrcas.Client.Web.Components;
 
 public partial class DetectionComponent
 {
-	private string _id;
-	private string _userId;
-	private Detection _initializedDetection;
-	private bool _submitting;
-	private TextInfo _ti = new CultureInfo("en-US", false).TextInfo;
+    private string _id;
+    private string _userId;
+    private Detection _initializedDetection;
+    private bool _submitting;
+    private TextInfo _ti = new CultureInfo("en-US", false).TextInfo;
 
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IAccountService AccountService { get; set; }
+    [Inject]
+    IAccountService AccountService { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	[Inject]
-	NavigationManager NavigationManager { get; set; }
+    [Inject]
+    NavigationManager NavigationManager { get; set; }
 
-	[Inject]
-	IConfiguration Configuration { get; set; }
+    [Inject]
+    IConfiguration Configuration { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Parameter]
-	public Detection Detection { get; set; }
+    [Parameter]
+    public Detection Detection { get; set; }
 
-	[Parameter]
-	public EventCallback<DetectionUpdate> SubmitCallback { get; set; }
+    [Parameter]
+    public EventCallback<DetectionUpdate> SubmitCallback { get; set; }
 
-	private string[] optionList = new string[] { "Yes", "No", "Don't Know" };
+    private string[] optionList = new string[] { "Yes", "No", "Don't Know" };
 
-	private string CardSpectrogramId { get => $"spectrogram-card-{_id}"; }
-	private string CardWaveformId { get => $"waveform-card-{_id}"; }
-	private string CardPlayButtonId { get => $"play-card-{_id}"; }
-	private string CardElapsedTimeId { get => $"elapsed-card-{_id}"; }
-	private string CardDurationTimeId { get => $"duration-card-{_id}"; }
+    private string CardSpectrogramId { get => $"spectrogram-card-{_id}"; }
+    private string CardWaveformId { get => $"waveform-card-{_id}"; }
+    private string CardPlayButtonId { get => $"play-card-{_id}"; }
+    private string CardElapsedTimeId { get => $"elapsed-card-{_id}"; }
+    private string CardDurationTimeId { get => $"duration-card-{_id}"; }
 
-	private string ModalSpectrogramPanelId { get => $"spectrogram-panel-modal-{_id}"; }
-	private string ModalSpectrogramId { get => $"spectrogram-modal-{_id}"; }
-	private string ModalWaveformId { get => $"waveform-modal-{_id}"; }
-	private string ModalPlayButtonId { get => $"play-modal-{_id}"; }
-	private string ModalElapsedTimeId { get => $"elapsed-modal-{_id}"; }
-	private string ModalDurationTimeId { get => $"duration-modal-{_id}"; }
+    private string ModalSpectrogramPanelId { get => $"spectrogram-panel-modal-{_id}"; }
+    private string ModalSpectrogramId { get => $"spectrogram-modal-{_id}"; }
+    private string ModalWaveformId { get => $"waveform-modal-{_id}"; }
+    private string ModalPlayButtonId { get => $"play-modal-{_id}"; }
+    private string ModalElapsedTimeId { get => $"elapsed-modal-{_id}"; }
+    private string ModalDurationTimeId { get => $"duration-modal-{_id}"; }
 
-	private string ModalMapPanelId { get => $"map-panel-modal-{_id}"; }
-	private string BingMapId { get => $"bingMap-modal-{_id}"; }
+    private string ModalMapPanelId { get => $"map-panel-modal-{_id}"; }
+    private string BingMapId { get => $"bingMap-modal-{_id}"; }
 
-	private string ModalLinkId { get => $"link-panel-modal-{_id}"; }
+    private string ModalLinkId { get => $"link-panel-modal-{_id}"; }
 
-	private string DetectionCount { get => (Detection.Annotations.Count == 1) ? "1 detection" : $"{Detection.Annotations.Count} detections"; }
+    private string DetectionCount { get => (Detection.Annotations.Count == 1) ? "1 detection" : $"{Detection.Annotations.Count} detections"; }
 
-	private string AverageConfidence { get => $"{Detection.Confidence.ToString("00.##")}% average confidence"; }
+    private string AverageConfidence { get => $"{Detection.Confidence.ToString("00.##")}% average confidence"; }
 
-	private bool IsSubmitDisabled { get => _submitting || string.IsNullOrWhiteSpace(Detection.Found); }
+    private bool IsSubmitDisabled { get => _submitting || string.IsNullOrWhiteSpace(Detection.Found); }
 
-	private string WasFound	{ get => _ti.ToTitleCase(Detection.Found); }
+    private string WasFound { get => _ti.ToTitleCase(Detection.Found); }
 
-	private string LinkUrl { get => $"{NavigationManager.BaseUri}detections/detection/{Detection.Id}"; }
+    private string LinkUrl { get => $"{NavigationManager.BaseUri}detections/detection/{Detection.Id}"; }
 
-	public List<string> GetSuggestedTagList(Detection d)
-	{
-		var suggestedTags = new List<string>();
+    public List<string> GetSuggestedTagList(Detection d)
+    {
+        var suggestedTags = new List<string>();
 
-		// Add any tags not in TagList that were leaf tags in the most recently moderated detection.
-		foreach (var tag in TagCache.GetTags(_userId))
-		{
-			if (!d.TagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
-			{
-				suggestedTags.Add(tag);
-			}
-		}
+        // Add any tags not in TagList that were leaf tags in the most recently moderated detection.
+        foreach (var tag in TagCache.GetTags(_userId))
+        {
+            if (!d.TagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
+            {
+                suggestedTags.Add(tag);
+            }
+        }
 
-		foreach (var tag in d.SuggestedTagList)
-		{
-			if (!suggestedTags.Contains(tag, StringComparer.OrdinalIgnoreCase))
-			{
-				suggestedTags.Add(tag);
-			}
-		}
+        foreach (var tag in d.SuggestedTagList)
+        {
+            if (!suggestedTags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+            {
+                suggestedTags.Add(tag);
+            }
+        }
 
-		// Add any default tag suggestions from the DEFAULT_TAG_SUGGESTIONS environment variable.
-		var defaultTagSuggestions = Configuration["DEFAULT_TAG_SUGGESTIONS"];
-		if (!string.IsNullOrWhiteSpace(defaultTagSuggestions))
-		{
-			foreach (var tag in defaultTagSuggestions.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-			{
-				if (!d.TagList.Contains(tag, StringComparer.OrdinalIgnoreCase) &&
-					!suggestedTags.Contains(tag, StringComparer.OrdinalIgnoreCase))
-				{
-					suggestedTags.Add(tag);
-				}
-			}
-		}
+        // Add any default tag suggestions from the DEFAULT_TAG_SUGGESTIONS environment variable.
+        var defaultTagSuggestions = Configuration["DEFAULT_TAG_SUGGESTIONS"];
+        if (!string.IsNullOrWhiteSpace(defaultTagSuggestions))
+        {
+            foreach (var tag in defaultTagSuggestions.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!d.TagList.Contains(tag, StringComparer.OrdinalIgnoreCase) &&
+                    !suggestedTags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+                {
+                    suggestedTags.Add(tag);
+                }
+            }
+        }
 
-		return suggestedTags;
-	}
+        return suggestedTags;
+    }
 
-	protected override async Task OnParametersSetAsync()
-	{
-		_id = Detection.Id;
+    protected override async Task OnParametersSetAsync()
+    {
+        _id = Detection.Id;
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
 
-		// Unreviewed detections are being initially populated in the database as "No"
-		// I am manually resetting it here when the reviewed status is false so that the record,
-		// can be unsubmittable until the user has changed Found to "Yes", "No", or "Don't Know"
+        // Unreviewed detections are being initially populated in the database as "No"
+        // I am manually resetting it here when the reviewed status is false so that the record,
+        // can be unsubmittable until the user has changed Found to "Yes", "No", or "Don't Know"
 
-		// TODO: Determine whether or not we should change the initial Found state
-		//       from No to something other than the three options we give the user
+        // TODO: Determine whether or not we should change the initial Found state
+        //       from No to something other than the three options we give the user
 
-		// Only initialize each detection once. This hook runs again on every
-		// parent re-render with the same Detection instance, and resetting
-		// then would wipe a verdict the moderator already selected (e.g., right
-		// after a failed submit shows its retry toast).
-		if (!Detection.Reviewed && !ReferenceEquals(Detection, _initializedDetection))
-		{
-			_initializedDetection = Detection;
-			Detection.Found = string.Empty;
+        // Only initialize each detection once. This hook runs again on every
+        // parent re-render with the same Detection instance, and resetting
+        // then would wipe a verdict the moderator already selected (e.g., right
+        // after a failed submit shows its retry toast).
+        if (!Detection.Reviewed && !ReferenceEquals(Detection, _initializedDetection))
+        {
+            _initializedDetection = Detection;
+            Detection.Found = string.Empty;
 
-			if (string.IsNullOrEmpty(Detection.Tags))
-			{
-				if (Detection.GlobalPredictionLabel == "transient")
-				{
-					AddTag("transient");
-				}
-				else if (Detection.GlobalPredictionLabel == "humpback")
-				{
-					AddTag("humpback");
-				}
+            if (string.IsNullOrEmpty(Detection.Tags))
+            {
+                if (Detection.GlobalPredictionLabel == "transient")
+                {
+                    AddTag("transient");
+                }
+                else if (Detection.GlobalPredictionLabel == "humpback")
+                {
+                    AddTag("humpback");
+                }
 
-				// Don't add the "srkw" tag here because we want the user
-				// to explicitly select it if they see it in the audio.
-			}
+                // Don't add the "srkw" tag here because we want the user
+                // to explicitly select it if they see it in the audio.
+            }
 
-			// If Comments is of the form "AI: A and B", then parse out the B and add it too.
-			if (!string.IsNullOrEmpty(Detection.Comments))
-			{
-				var match = Regex.Match(Detection.Comments, @"AI:\s*(?<a>.*?)\s*and\s*(?<b>.*)");
-				if (match.Success)
-				{
-					string b = match.Groups["b"].Value;
-					AddTag(b);
-				}
-			}
+            // If Comments is of the form "AI: A and B", then parse out the B and add it too.
+            if (!string.IsNullOrEmpty(Detection.Comments))
+            {
+                var match = Regex.Match(Detection.Comments, @"AI:\s*(?<a>.*?)\s*and\s*(?<b>.*)");
+                if (match.Success)
+                {
+                    string b = match.Groups["b"].Value;
+                    AddTag(b);
+                }
+            }
 
-			// Handle model tag aliases / legacy tags.
-			// PODS-AI may include "resident"; OrcaHello uses "srkw" only when the moderator explicitly
-			// selects SRKW=yes, so strip "resident" during initialization to avoid an extra tag.
-			// If we later need to map other model labels (e.g., "transient" -> "biggs"), do it here.
-			// This does not block moderators from manually entering "resident" later.
-			if (Detection.TagList.Contains("resident", StringComparer.OrdinalIgnoreCase))
-			{
-				RemoveTag("resident");
+            // Handle model tag aliases / legacy tags.
+            // PODS-AI may include "resident"; OrcaHello uses "srkw" only when the moderator explicitly
+            // selects SRKW=yes, so strip "resident" during initialization to avoid an extra tag.
+            // If we later need to map other model labels (e.g., "transient" -> "biggs"), do it here.
+            // This does not block moderators from manually entering "resident" later.
+            if (Detection.TagList.Contains("resident", StringComparer.OrdinalIgnoreCase))
+            {
+                RemoveTag("resident");
 
-				// Don't add srkw since that would make the SRKWFound
-				// button default to yes.  Instead leave it unselected,
-				// like OrcaHello candidates do.
-			}
-		}
-	}
+                // Don't add srkw since that would make the SRKWFound
+                // button default to yes.  Instead leave it unselected,
+                // like OrcaHello candidates do.
+            }
+        }
+    }
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-		// Invoked on every render because the card may not be in the DOM yet on the
-		// first render (e.g. while the single detection page is still loading the record);
-		// the JS side is idempotent and exits early once the shades exist.
-		await JSRuntime.InvokeVoidAsync("DrawRegionShades", _id, Detection.AudioUri, RegionsJson);
-	}
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Invoked on every render because the card may not be in the DOM yet on the
+        // first render (e.g. while the single detection page is still loading the record);
+        // the JS side is idempotent and exits early once the shades exist.
+        await JSRuntime.InvokeVoidAsync("DrawRegionShades", _id, Detection.AudioUri, RegionsJson);
+    }
 
-	private void SetFoundValue(string found)
-	{
-		Detection.Found = found;
+    private void SetFoundValue(string found)
+    {
+        Detection.Found = found;
 
-		switch (found)
-		{
-			case "Yes":
-				AddTag("srkw");
-				break;
-			default: // No or Don't Know.
-				RemoveTag("srkw");
-				break;
-		}
-	}
+        switch (found)
+        {
+            case "Yes":
+                AddTag("srkw");
+                break;
+            default: // No or Don't Know.
+                RemoveTag("srkw");
+                break;
+        }
+    }
 
-	/// <summary>
-	/// Add a tag to the detection's tag list, ensuring that it is added before its parent tag if present, and also adding the parent tag if not already present.
-	/// If the tag is "srkw" and the Found value is not "Yes", it sets Found to "Yes".
-	/// </summary>
-	/// <param name="tag">Tag to add</param>
-	private void AddTag(string tag)
-	{
-		if (string.IsNullOrWhiteSpace(tag))
-		{
-			return;
-		}
-		var tagList = Detection.TagList;
-		if (tagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
-		{
-			// Nothing to do.
-			return;
-		}
+    /// <summary>
+    /// Add a tag to the detection's tag list, ensuring that it is added before its parent tag if present, and also adding the parent tag if not already present.
+    /// If the tag is "srkw" and the Found value is not "Yes", it sets Found to "Yes".
+    /// </summary>
+    /// <param name="tag">Tag to add</param>
+    private void AddTag(string tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            return;
+        }
+        var tagList = Detection.TagList;
+        if (tagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
+        {
+            // Nothing to do.
+            return;
+        }
 
-		// Add the suggested tag before its parent tag if present, otherwise add it to the end of the list.
-		Detection.TagHierarchy.TryGetValue(tag, out string parentTag);
-		if (!string.IsNullOrWhiteSpace(parentTag))
-	        {
-			var parentIndex = tagList.FindIndex(t => t.Equals(parentTag, StringComparison.OrdinalIgnoreCase));
-			if (parentIndex >= 0)
-			{
-				tagList.Insert(parentIndex, tag);
-			}
-			else
-			{
-				tagList.Add(tag);
-			}
-		}
-		else
-		{
-			tagList.Add(tag);
-		}
-		Detection.Tags = string.Join(";", tagList);
+        // Add the suggested tag before its parent tag if present, otherwise add it to the end of the list.
+        Detection.TagHierarchy.TryGetValue(tag, out string parentTag);
+        if (!string.IsNullOrWhiteSpace(parentTag))
+        {
+            var parentIndex = tagList.FindIndex(t => t.Equals(parentTag, StringComparison.OrdinalIgnoreCase));
+            if (parentIndex >= 0)
+            {
+                tagList.Insert(parentIndex, tag);
+            }
+            else
+            {
+                tagList.Add(tag);
+            }
+        }
+        else
+        {
+            tagList.Add(tag);
+        }
+        Detection.Tags = string.Join(";", tagList);
 
-		// Add parent tag if not already present.
-		if (!string.IsNullOrEmpty(parentTag))
-		{
-			AddTag(parentTag);
-		}
+        // Add parent tag if not already present.
+        if (!string.IsNullOrEmpty(parentTag))
+        {
+            AddTag(parentTag);
+        }
 
-		if (tag.Equals("srkw", StringComparison.OrdinalIgnoreCase) && Detection.Found != "Yes")
-		{
-			SetFoundValue("Yes");
-		}
-	}
+        if (tag.Equals("srkw", StringComparison.OrdinalIgnoreCase) && Detection.Found != "Yes")
+        {
+            SetFoundValue("Yes");
+        }
+    }
 
-	/// <summary>
-	/// Remove a tag from the detection's tag list.
-	/// Also remove any child tags that have this tag as their parent in the hierarchy.
-	/// </summary>
-	/// <param name="tag">Tag to remove</param>
-	private void RemoveTag(string tag)
-	{
-		if (string.IsNullOrWhiteSpace(tag))
-		{
-			return;
-		}
-		var tagList = Detection.TagList;
-		if (!tagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
-		{
-			// Nothing to do.
-			return;
-		}
+    /// <summary>
+    /// Remove a tag from the detection's tag list.
+    /// Also remove any child tags that have this tag as their parent in the hierarchy.
+    /// </summary>
+    /// <param name="tag">Tag to remove</param>
+    private void RemoveTag(string tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            return;
+        }
+        var tagList = Detection.TagList;
+        if (!tagList.Contains(tag, StringComparer.OrdinalIgnoreCase))
+        {
+            // Nothing to do.
+            return;
+        }
 
-		tagList.RemoveAll(t => t.Equals(tag, StringComparison.OrdinalIgnoreCase));
-		Detection.Tags = string.Join(";", tagList);
+        tagList.RemoveAll(t => t.Equals(tag, StringComparison.OrdinalIgnoreCase));
+        Detection.Tags = string.Join(";", tagList);
 
-		// Remove child tags if they exist in the hierarchy.
-		foreach (var pair in Detection.TagHierarchy)
-		{
-			if ((pair.Value != null) && pair.Value.Equals(tag, StringComparison.OrdinalIgnoreCase))
-			{
-				RemoveTag(pair.Key);
-			}
-		}
+        // Remove child tags if they exist in the hierarchy.
+        foreach (var pair in Detection.TagHierarchy)
+        {
+            if ((pair.Value != null) && pair.Value.Equals(tag, StringComparison.OrdinalIgnoreCase))
+            {
+                RemoveTag(pair.Key);
+            }
+        }
 
-		// If we just removed the SRKW tag and the radio button says
-		// SRKW=yes, clear that.
-		if (tag.Equals("srkw", StringComparison.OrdinalIgnoreCase) && Detection.Found == "Yes")
-		{
-			SetFoundValue(string.Empty);
-		}
-	}
+        // If we just removed the SRKW tag and the radio button says
+        // SRKW=yes, clear that.
+        if (tag.Equals("srkw", StringComparison.OrdinalIgnoreCase) && Detection.Found == "Yes")
+        {
+            SetFoundValue(string.Empty);
+        }
+    }
 
     /// <summary>
     /// Process a change in the tags string, updating the Detection's TagList accordingly.
@@ -316,92 +316,92 @@ public partial class DetectionComponent
     }
 
     private async Task SubmitUpdate()
-	{
-		// Guard before any await: a second click can be dispatched before the
-		// disabled attribute reaches the browser, and it must not enter here.
-		if (_submitting)
-		{
-			return;
-		}
-		_submitting = true;
+    {
+        // Guard before any await: a second click can be dispatched before the
+        // disabled attribute reaches the browser, and it must not enter here.
+        if (_submitting)
+        {
+            return;
+        }
+        _submitting = true;
 
-		try
-		{
-			var request = new DetectionUpdate()
-			{
-				Id = Detection.Id,
-				Comments = Detection.Comments,
-				Tags = Detection.Tags,
-				Moderator = await AccountService.GetUsername(),
-				Moderated = DateTime.Now,
-				Reviewed = true,
-				Found = Detection.Found
-			};
+        try
+        {
+            var request = new DetectionUpdate()
+            {
+                Id = Detection.Id,
+                Comments = Detection.Comments,
+                Tags = Detection.Tags,
+                Moderator = await AccountService.GetUsername(),
+                Moderated = DateTime.Now,
+                Reviewed = true,
+                Found = Detection.Found
+            };
 
-			await SubmitCallback.InvokeAsync(request);
-		}
-		catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
-		{
-			// One guard for every page that renders this component. Keep the
-			// card and the moderator's selections untouched for a retry. The
-			// wording stays generic: the same exception covers an unreachable
-			// server and an error response, and the service logs the detail.
-			ToastService.ShowError("The verdict was not saved. Please try again.");
-		}
-		finally
-		{
-			_submitting = false;
-		}
-	}
+            await SubmitCallback.InvokeAsync(request);
+        }
+        catch (Exception exception) when (exception is HttpRequestException || exception is TaskCanceledException)
+        {
+            // One guard for every page that renders this component. Keep the
+            // card and the moderator's selections untouched for a retry. The
+            // wording stays generic: the same exception covers an unreachable
+            // server and an error response, and the service logs the detail.
+            ToastService.ShowError("The verdict was not saved. Please try again.");
+        }
+        finally
+        {
+            _submitting = false;
+        }
+    }
 
-	private async Task ToggleCardPlayer()
-	{
-		await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri);
-	}
+    private async Task ToggleCardPlayer()
+    {
+        await JSRuntime.InvokeVoidAsync("CardSpectrogram", _id, Detection.AudioUri);
+    }
 
-	private async Task ToggleModalPlayer()
-	{
-		var isPlaying = await JSRuntime.InvokeAsync<bool>("IsPlayerActive");
+    private async Task ToggleModalPlayer()
+    {
+        var isPlaying = await JSRuntime.InvokeAsync<bool>("IsPlayerActive");
 
-		if (!isPlaying)
-		{
-			await InitializeModalPlayer();
-		}
+        if (!isPlaying)
+        {
+            await InitializeModalPlayer();
+        }
 
-		await JSRuntime.InvokeVoidAsync("ToggleModalSpectrogram");
-	}
+        await JSRuntime.InvokeVoidAsync("ToggleModalSpectrogram");
+    }
 
-	private string RegionsJson =>
-		JsonSerializer.Serialize(Detection.Annotations.Select(annotation => new
-		{
-			start = annotation.StartTime,
-			end = annotation.EndTime,
-			color = "rgba(255, 255, 255, 0.1)"
-		}));
+    private string RegionsJson =>
+        JsonSerializer.Serialize(Detection.Annotations.Select(annotation => new
+        {
+            start = annotation.StartTime,
+            end = annotation.EndTime,
+            color = "rgba(255, 255, 255, 0.1)"
+        }));
 
-	private async Task InitializeModalPlayer()
-	{
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		await JSRuntime.InvokeVoidAsync("InitializeModalSpectrogram", _id,
-			Detection.AudioUri);
-	}
+    private async Task InitializeModalPlayer()
+    {
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        await JSRuntime.InvokeVoidAsync("InitializeModalSpectrogram", _id,
+            Detection.AudioUri);
+    }
 
-	private async Task InitializeModalMap()
-	{
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		await JSRuntime.InvokeVoidAsync("LoadBingMap", _id, 
-			Detection.Location?.Latitude, Detection.Location?.Longitude);
-	}
+    private async Task InitializeModalMap()
+    {
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        await JSRuntime.InvokeVoidAsync("LoadBingMap", _id,
+            Detection.Location?.Latitude, Detection.Location?.Longitude);
+    }
 
-	private async Task KillPlayer()
-	{
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    private async Task KillPlayer()
+    {
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 
-	private async Task ActivateLink(string url)
-	{
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+    private async Task ActivateLink(string url)
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
 
-		NavigationManager.NavigateTo(url, true);
-	}
+        NavigationManager.NavigateTo(url, true);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/LoginWarningComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/LoginWarningComponent.razor
@@ -1,17 +1,17 @@
 ﻿<div class="modal fade" id="loginModal" tabindex="-1" role="dialog" 
-	 aria-labelledby="loginModal" aria-hidden="true">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Log In First</h5>
-				<button class="close" type="button" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">×</span>
-				</button>
-			</div>
-			<div class="modal-body">You must click "Log In" in the upper right-hand corner of the screen before you can click "Submit".</div>
-			<div class="modal-footer">
-				<button class="btn btn-primary" type="button" data-dismiss="modal">Ok</button>
-			</div>
-		</div>
-	</div>
+     aria-labelledby="loginModal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Log In First</h5>
+                <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+            <div class="modal-body">You must click "Log In" in the upper right-hand corner of the screen before you can click "Submit".</div>
+            <div class="modal-footer">
+                <button class="btn btn-primary" type="button" data-dismiss="modal">Ok</button>
+            </div>
+        </div>
+    </div>
 </div>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/LogoutComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/LogoutComponent.razor
@@ -1,19 +1,19 @@
 ﻿<!-- Logout Modal-->
 <div class="modal fade" id="logoutModal" tabindex="-1" role="dialog" 
-	 aria-labelledby="logoutModal" aria-hidden="true">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Ready to Leave?</h5>
-				<button class="close" type="button" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">×</span>
-				</button>
-			</div>
-			<div class="modal-body">Select "Logout" below if you are ready to end your current session.</div>
-			<div class="modal-footer">
-				<button class="btn btn-secondary" type="button" data-dismiss="modal">Cancel</button>
-				<button class="btn btn-primary" data-dismiss="modal" @onclick="Logout">Log Out</button>
-			</div>
-		</div>
-	</div>
+     aria-labelledby="logoutModal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Ready to Leave?</h5>
+                <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+            <div class="modal-body">Select "Logout" below if you are ready to end your current session.</div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" type="button" data-dismiss="modal">Cancel</button>
+                <button class="btn btn-primary" data-dismiss="modal" @onclick="Logout">Log Out</button>
+            </div>
+        </div>
+    </div>
 </div>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/MetricsFilterComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/MetricsFilterComponent.razor
@@ -1,19 +1,19 @@
 ﻿<EditForm Model="FilterOptions" class="container-fluid px-0 mb-2">
-	<div class="row">
-		<div class="col-12 col-md-4 col-lg-3">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Timeframe:</label>
-				<InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
-					<option value="30m">Last 30 Minutes</option>
-					<option value="24h">Last 24 Hours</option>
-					<option value="1w">Last Week</option>
-					<option value="1m">Last Month</option>
-					<option value="all">All</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-lg-3 mt-1 mt-lg-0 pt-lg-4">
-			<button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
-		</div>
-	</div>
+    <div class="row">
+        <div class="col-12 col-md-4 col-lg-3">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Timeframe:</label>
+                <InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
+                    <option value="30m">Last 30 Minutes</option>
+                    <option value="24h">Last 24 Hours</option>
+                    <option value="1w">Last Week</option>
+                    <option value="1m">Last Month</option>
+                    <option value="all">All</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3 mt-1 mt-lg-0 pt-lg-4">
+            <button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
+        </div>
+    </div>
 </EditForm>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/MetricsFilterComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/MetricsFilterComponent.razor.cs
@@ -2,14 +2,14 @@
 
 public partial class MetricsFilterComponent
 {
-	[Parameter]
-	public MetricsFilterDTO FilterOptions { get; set; } = new MetricsFilterDTO();
+    [Parameter]
+    public MetricsFilterDTO FilterOptions { get; set; } = new MetricsFilterDTO();
 
-	[Parameter]
-	public EventCallback<MetricsFilterDTO> ApplyFilterCallback { get; set; }
+    [Parameter]
+    public EventCallback<MetricsFilterDTO> ApplyFilterCallback { get; set; }
 
-	private async Task ApplyFilter()
-	{
-		await ApplyFilterCallback.InvokeAsync(FilterOptions);
-	}
+    private async Task ApplyFilter()
+    {
+        await ApplyFilterCallback.InvokeAsync(FilterOptions);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PageHeadingComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PageHeadingComponent.razor
@@ -1,5 +1,5 @@
 ﻿<h1 class="h3 mb-2 text-gray-800" style="display: inline-block">@Title</h1>
 @if (PillCount > 0)
 {
-	<span class="badge badge-primary text-medium" style="vertical-align: top">@PillCount</span>
+    <span class="badge badge-primary text-medium" style="vertical-align: top">@PillCount</span>
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PageHeadingComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PageHeadingComponent.razor.cs
@@ -2,9 +2,9 @@
 
 public partial class PageHeadingComponent
 {
-	[Parameter]
-	public string Title { get; set; }
+    [Parameter]
+    public string Title { get; set; }
 
-	[Parameter]
-	public int PillCount { get; set; }
+    [Parameter]
+    public int PillCount { get; set; }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor
@@ -1,12 +1,12 @@
 ﻿<nav>
-	<ul class="pagination">
-		@foreach (var link in links)
-		{
-			<li @onclick="(() => SelectPage(link))"
-				style="cursor: pointer;"
-				class="page-item @(link.Enabled ? null : "disabled") @(link.Active ? "active" : null)">
-				<span class="page-link" href="#">@link.Text</span>
-			</li>
-		}
-	</ul>
+    <ul class="pagination">
+        @foreach (var link in links)
+        {
+            <li @onclick="(() => SelectPage(link))"
+                style="cursor: pointer;"
+                class="page-item @(link.Enabled ? null : "disabled") @(link.Active ? "active" : null)">
+                <span class="page-link" href="#">@link.Text</span>
+            </li>
+        }
+    </ul>
 </nav>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
@@ -2,54 +2,54 @@
 
 public partial class PaginationComponent
 {
-	[Parameter]
-	public PaginationOptionsDTO PaginationOptions { get; set; }
+    [Parameter]
+    public PaginationOptionsDTO PaginationOptions { get; set; }
 
-	[Parameter]
-	public PaginationResultsDTO PaginationResults { get; set; }
+    [Parameter]
+    public PaginationResultsDTO PaginationResults { get; set; }
 
-	[Parameter]
-	public EventCallback<PaginationOptionsDTO> SelectPageCallback { get; set; }
+    [Parameter]
+    public EventCallback<PaginationOptionsDTO> SelectPageCallback { get; set; }
 
-	List<PageLinkDTO> links;
+    List<PageLinkDTO> links;
 
-	protected override void OnParametersSet()
-	{
-		BuildPaginationLinks();
-	}
+    protected override void OnParametersSet()
+    {
+        BuildPaginationLinks();
+    }
 
-	private async Task SelectPage(PageLinkDTO link)
-	{
-		if (link.Page == PaginationResults.CurrentPage || !link.Enabled)
-			return;
+    private async Task SelectPage(PageLinkDTO link)
+    {
+        if (link.Page == PaginationResults.CurrentPage || !link.Enabled)
+            return;
 
-		PaginationOptions.Page = link.Page;
-		await SelectPageCallback.InvokeAsync(PaginationOptions);
-	}
+        PaginationOptions.Page = link.Page;
+        await SelectPageCallback.InvokeAsync(PaginationOptions);
+    }
 
-	private void BuildPaginationLinks()
-	{
-		links = new List<PageLinkDTO>();
-		var isPreviousPageLinkEnabled = PaginationResults.CurrentPage != 1;
-		var previousPage = PaginationResults.CurrentPage - 1;
-		links.Add(new PageLinkDTO(previousPage, isPreviousPageLinkEnabled, "Previous"));
+    private void BuildPaginationLinks()
+    {
+        links = new List<PageLinkDTO>();
+        var isPreviousPageLinkEnabled = PaginationResults.CurrentPage != 1;
+        var previousPage = PaginationResults.CurrentPage - 1;
+        links.Add(new PageLinkDTO(previousPage, isPreviousPageLinkEnabled, "Previous"));
 
-		for (int i = 1; i <= PaginationResults.TotalNumberOfPages; i++)
-		{
-			if (i == 1 ||
-				i == PaginationResults.TotalNumberOfPages ||
-				(i >= PaginationResults.CurrentPage - PaginationOptions.Radius &&
-				 i <= PaginationResults.CurrentPage + PaginationOptions.Radius))
-			{
-				links.Add(new PageLinkDTO(i) { Active = PaginationResults.CurrentPage == i });
-			}
-		}
+        for (int i = 1; i <= PaginationResults.TotalNumberOfPages; i++)
+        {
+            if (i == 1 ||
+                i == PaginationResults.TotalNumberOfPages ||
+                (i >= PaginationResults.CurrentPage - PaginationOptions.Radius &&
+                 i <= PaginationResults.CurrentPage + PaginationOptions.Radius))
+            {
+                links.Add(new PageLinkDTO(i) { Active = PaginationResults.CurrentPage == i });
+            }
+        }
 
-		var isNextPageLinkEnabled = PaginationResults.TotalNumberOfPages > 0 
-			&& PaginationResults.CurrentPage != PaginationResults.TotalNumberOfPages;
-		var nextPage = PaginationResults.CurrentPage + 1;
+        var isNextPageLinkEnabled = PaginationResults.TotalNumberOfPages > 0
+            && PaginationResults.CurrentPage != PaginationResults.TotalNumberOfPages;
+        var nextPage = PaginationResults.CurrentPage + 1;
 
-		links.Add(new PageLinkDTO(nextPage, isNextPageLinkEnabled, "Next"));
-	}
+        links.Add(new PageLinkDTO(nextPage, isNextPageLinkEnabled, "Next"));
+    }
 }
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/ReviewedFilterComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/ReviewedFilterComponent.razor
@@ -1,41 +1,41 @@
 ﻿<EditForm Model="FilterOptions" class="container-fluid px-0 mb-2">
-	<div class="row">
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Sort By:</label>
-				<InputSelect id="sortBy" class="form-control" @bind-Value="FilterOptions.SortBy">
-					<option value="confidence">Confidence</option>
-					<option value="timestamp">Timestamp</option>
-					<option value="moderator">Moderator</option>
-					<option value="moderated">Date Moderated</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Sort Order:</label>
-				<InputSelect id="sortOrder" class="form-control" @bind-Value="FilterOptions.SortOrder">
-					<option value="desc">Descending</option>
-					<option value="asc">Ascending</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Timeframe:</label>
-				<InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
-					<option value="30m">Last 30 Minutes</option>
-					<option value="3h">Last 3 Hours</option>
-					<option value="6h">Last 6 Hours</option>
-					<option value="24h">Last 24 Hours</option>
-					<option value="1w">Last Week</option>
-					<option value="1m">Last Month</option>
-					<option value="all">All</option>
-					<option value="range">Select Date Range</option>
-				</InputSelect>
-			</div>
-		</div>
-		 @if(FilterOptions.Timeframe=="range")
+    <div class="row">
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Sort By:</label>
+                <InputSelect id="sortBy" class="form-control" @bind-Value="FilterOptions.SortBy">
+                    <option value="confidence">Confidence</option>
+                    <option value="timestamp">Timestamp</option>
+                    <option value="moderator">Moderator</option>
+                    <option value="moderated">Date Moderated</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Sort Order:</label>
+                <InputSelect id="sortOrder" class="form-control" @bind-Value="FilterOptions.SortOrder">
+                    <option value="desc">Descending</option>
+                    <option value="asc">Ascending</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Timeframe:</label>
+                <InputSelect id="timeframe" class="form-control" @bind-Value="FilterOptions.Timeframe">
+                    <option value="30m">Last 30 Minutes</option>
+                    <option value="3h">Last 3 Hours</option>
+                    <option value="6h">Last 6 Hours</option>
+                    <option value="24h">Last 24 Hours</option>
+                    <option value="1w">Last Week</option>
+                    <option value="1m">Last Month</option>
+                    <option value="all">All</option>
+                    <option value="range">Select Date Range</option>
+                </InputSelect>
+            </div>
+        </div>
+         @if(FilterOptions.Timeframe=="range")
         {
         <div class="col-12 col-md-2 col-lg-2">
             <div class="form-group mb-0">
@@ -52,20 +52,20 @@
             </div>
         </div>
         }
-		<div class="col-12 col-md-2 col-lg-2">
-			<div class="form-group mb-0">
-				<label class="col-form-label mb-0 py-0">Location:</label>
-				<InputSelect id="location" class="form-control" @bind-Value="FilterOptions.Location">
-					@foreach (var location in AllLocations)
-					{
-						<option value="@location">@location</option>
-					}
-					<option value="all">All</option>
-				</InputSelect>
-			</div>
-		</div>
-		<div class="col-12 col-md-2 col-lg-2 mt-1 mt-lg-0 pt-lg-4">
-			<button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
-		</div>
-	</div>
+        <div class="col-12 col-md-2 col-lg-2">
+            <div class="form-group mb-0">
+                <label class="col-form-label mb-0 py-0">Location:</label>
+                <InputSelect id="location" class="form-control" @bind-Value="FilterOptions.Location">
+                    @foreach (var location in AllLocations)
+                    {
+                        <option value="@location">@location</option>
+                    }
+                    <option value="all">All</option>
+                </InputSelect>
+            </div>
+        </div>
+        <div class="col-12 col-md-2 col-lg-2 mt-1 mt-lg-0 pt-lg-4">
+            <button class="btn btn-success" type="submit" @onclick="(() => ApplyFilter())">Filter</button>
+        </div>
+    </div>
 </EditForm>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/ReviewedFilterComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/ReviewedFilterComponent.razor.cs
@@ -2,24 +2,24 @@
 
 public partial class ReviewedFilterComponent
 {
-	[Parameter]
-	public ReviewedFilterOptionsDTO FilterOptions { get; set; } = new ReviewedFilterOptionsDTO();
+    [Parameter]
+    public ReviewedFilterOptionsDTO FilterOptions { get; set; } = new ReviewedFilterOptionsDTO();
 
-	[Parameter]
-	public EventCallback<ReviewedFilterOptionsDTO> ApplyFilterCallback { get; set; }
+    [Parameter]
+    public EventCallback<ReviewedFilterOptionsDTO> ApplyFilterCallback { get; set; }
 
-	[Inject]
-	public AppSettings AppSettings { get; set; }
+    [Inject]
+    public AppSettings AppSettings { get; set; }
 
-	private List<string> AllLocations = new List<string>();
+    private List<string> AllLocations = new List<string>();
 
-	protected override void OnInitialized()
-	{
-		AllLocations = HydrophoneLocations.Locations.ToList();
-	}
+    protected override void OnInitialized()
+    {
+        AllLocations = HydrophoneLocations.Locations.ToList();
+    }
 
-	private async Task ApplyFilter()
-	{
-		await ApplyFilterCallback.InvokeAsync(FilterOptions);
-	}
+    private async Task ApplyFilter()
+    {
+        await ApplyFilterCallback.InvokeAsync(FilterOptions);
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor.cs
@@ -2,11 +2,11 @@
 
 public partial class SideBarComponent
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
-	
-	private async Task ToggleDisplay()
-	{
-		await JSRuntime.InvokeVoidAsync("ToggleSideBar");
-	}
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
+
+    private async Task ToggleDisplay()
+    {
+        await JSRuntime.InvokeVoidAsync("ToggleSideBar");
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/TopBarComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/TopBarComponent.razor
@@ -1,57 +1,57 @@
 ﻿<nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
 
-	<!-- Sidebar Toggle (Topbar) -->
-	<button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3" @onclick="ToggleSidebar">
-		<i class="fa fa-bars"></i>
-	</button>
+    <!-- Sidebar Toggle (Topbar) -->
+    <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3" @onclick="ToggleSidebar">
+        <i class="fa fa-bars"></i>
+    </button>
 
-	<!-- Topbar Navbar -->
-	<ul class="navbar-nav ml-auto">
+    <!-- Topbar Navbar -->
+    <ul class="navbar-nav ml-auto">
 
-		<li class="nav-item">
-			<a class="nav-link" @onclick="ToggleTheme" style="cursor:pointer;">
-				<span class="mr-2 text-gray-600 small"><i class="fas fa-adjust"></i> @theme</span>
-			</a>
-		</li>
+        <li class="nav-item">
+            <a class="nav-link" @onclick="ToggleTheme" style="cursor:pointer;">
+                <span class="mr-2 text-gray-600 small"><i class="fas fa-adjust"></i> @theme</span>
+            </a>
+        </li>
 
-		<li class="topbar-divider d-none d-sm-block"></li>
+        <li class="topbar-divider d-none d-sm-block"></li>
 
-		<li class="nav-item no-arrow">
-			<a class="nav-link">
-				<span class="mr-2 d-none d-lg-block d-sm-none text-gray-600 small text-nowrap">@DisplayDate</span>
-				<span class="mr-2 d-none d-sm-block d-lg-none text-gray-600 small text-nowrap">@ShortDisplayDate</span>
-			</a>
-		</li>
+        <li class="nav-item no-arrow">
+            <a class="nav-link">
+                <span class="mr-2 d-none d-lg-block d-sm-none text-gray-600 small text-nowrap">@DisplayDate</span>
+                <span class="mr-2 d-none d-sm-block d-lg-none text-gray-600 small text-nowrap">@ShortDisplayDate</span>
+            </a>
+        </li>
 
-		<li class="topbar-divider d-none d-sm-block"></li>
+        <li class="topbar-divider d-none d-sm-block"></li>
 
-		<AuthorizeView>
-			<Authorized>
-				<!-- Nav Item - User Information -->
-				<li class="nav-item dropdown no-arrow">
-										
-					<a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<span class="mr-2 d-none d-lg-inline text-gray-600 small">@DisplayName</span>
-						<img class="img-profile rounded-circle" src="img/avatar.png" height="60" width="60">
-					</a>
-					<!-- Dropdown - User Information -->
-					<div class="dropdown-menu dropdown-menu-right shadow animated--grow-in" aria-labelledby="userDropdown">
-						<a class="dropdown-item" href="/user/activity">
-							<i class="fas fa-list fa-sm fa-fw mr-2 text-gray-400"></i>
-							Activity Log
-						</a>
-						<div class="dropdown-divider"></div>
-						<a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">		
-							<i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>Logout
-						</a>
-					</div>
-				</li>
-			</Authorized>
-			<NotAuthorized>
-				<li class="nav-item no-arrow">
-					<button class="mt-3 btn btn-primary" @onclick="Login">Log In</button>
-				</li>
-			</NotAuthorized>
-		</AuthorizeView>
-	</ul>
+        <AuthorizeView>
+            <Authorized>
+                <!-- Nav Item - User Information -->
+                <li class="nav-item dropdown no-arrow">
+                                        
+                    <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="mr-2 d-none d-lg-inline text-gray-600 small">@DisplayName</span>
+                        <img class="img-profile rounded-circle" src="img/avatar.png" height="60" width="60">
+                    </a>
+                    <!-- Dropdown - User Information -->
+                    <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in" aria-labelledby="userDropdown">
+                        <a class="dropdown-item" href="/user/activity">
+                            <i class="fas fa-list fa-sm fa-fw mr-2 text-gray-400"></i>
+                            Activity Log
+                        </a>
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">       
+                            <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>Logout
+                        </a>
+                    </div>
+                </li>
+            </Authorized>
+            <NotAuthorized>
+                <li class="nav-item no-arrow">
+                    <button class="mt-3 btn btn-primary" @onclick="Login">Log In</button>
+                </li>
+            </NotAuthorized>
+        </AuthorizeView>
+    </ul>
 </nav>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/TopBarComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/TopBarComponent.razor.cs
@@ -2,69 +2,69 @@
 
 public partial class TopBarComponent
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
     [Inject]
-	IAccountService AccountService { get; set; }
+    IAccountService AccountService { get; set; }
 
-	[Parameter]
-	public string CurrentUrl { get; set; }
+    [Parameter]
+    public string CurrentUrl { get; set; }
 
-	private string DisplayName { get; set; }
+    private string DisplayName { get; set; }
 
-	private string DisplayDate { get; set; }
+    private string DisplayDate { get; set; }
 
-	private string ShortDisplayDate { get; set; }
+    private string ShortDisplayDate { get; set; }
 
-	public CancellationTokenSource CancellationTokenSource { get; set; }
+    public CancellationTokenSource CancellationTokenSource { get; set; }
 
-	[Parameter]
-	public EventCallback ToggleThemeCallback { get; set; }
+    [Parameter]
+    public EventCallback ToggleThemeCallback { get; set; }
 
-	private string theme = "Dark";
+    private string theme = "Dark";
 
-	private void SetDateTime()
-	{
-		var now = DateTime.UtcNow;
-		DisplayDate = DateHelper.UTCToPDT(now);
-		ShortDisplayDate = DateHelper.UTCToPDT(now, true);
-	}
-
-	protected override async Task OnInitializedAsync()
-	{
-		DisplayName = await AccountService.GetDisplayname();
-		SetDateTime();
-		CancellationTokenSource = new CancellationTokenSource();
-		await RealTimeUpdate(CancellationTokenSource.Token);
-	}
-
-	private async Task ToggleTheme()
-	{
-		theme = (theme == "Dark") ? "Light" : "Dark";
-		await ToggleThemeCallback.InvokeAsync(null);
-	}
-
-	private async Task ToggleSidebar()
-	{
-		await JSRuntime.InvokeVoidAsync("ToggleSideBar");
-	}
-
-	private async Task Login()
+    private void SetDateTime()
     {
-		await AccountService.Login();
+        var now = DateTime.UtcNow;
+        DisplayDate = DateHelper.UTCToPDT(now);
+        ShortDisplayDate = DateHelper.UTCToPDT(now, true);
     }
 
-	public async Task RealTimeUpdate(CancellationToken cancellationToken)
-	{
-		while(!cancellationToken.IsCancellationRequested)
-		{
-			await Task.Delay(1000, cancellationToken);
-			if (!cancellationToken.IsCancellationRequested)
-			{
-				SetDateTime();
-				await InvokeAsync(() => this.StateHasChanged());
-			}
-		}
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        DisplayName = await AccountService.GetDisplayname();
+        SetDateTime();
+        CancellationTokenSource = new CancellationTokenSource();
+        await RealTimeUpdate(CancellationTokenSource.Token);
+    }
+
+    private async Task ToggleTheme()
+    {
+        theme = (theme == "Dark") ? "Light" : "Dark";
+        await ToggleThemeCallback.InvokeAsync(null);
+    }
+
+    private async Task ToggleSidebar()
+    {
+        await JSRuntime.InvokeVoidAsync("ToggleSideBar");
+    }
+
+    private async Task Login()
+    {
+        await AccountService.Login();
+    }
+
+    public async Task RealTimeUpdate(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await Task.Delay(1000, cancellationToken);
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                SetDateTime();
+                await InvokeAsync(() => this.StateHasChanged());
+            }
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Extensions/Services.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Extensions/Services.cs
@@ -9,7 +9,7 @@ public static class Services
     {
         // Register server-side token store as singleton.
         builder.Services.AddSingleton<ITokenStore, ServerSideTokenStore>();
-        
+
         // Register circuit handler.
         builder.Services.AddScoped<CircuitHandlerService>();
         builder.Services.AddScoped<CircuitHandler>(sp => sp.GetRequiredService<CircuitHandlerService>());

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Helpers/InputRadio.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Helpers/InputRadio.razor
@@ -3,35 +3,35 @@
 @inherits InputBase<TValue>
 
 <input @attributes="AdditionalAttributes" type="radio" value="@SelectedValue"
-	   checked="@(SelectedValue.Equals(Value))" @onchange="OnChange" />
+       checked="@(SelectedValue.Equals(Value))" @onchange="OnChange" />
 
 @code {
-	[Parameter]
-	public TValue SelectedValue { get; set; }
+    [Parameter]
+    public TValue SelectedValue { get; set; }
 
-	private void OnChange(ChangeEventArgs args)
-	{
-		CurrentValueAsString = args.Value.ToString();
-	}
+    private void OnChange(ChangeEventArgs args)
+    {
+        CurrentValueAsString = args.Value.ToString();
+    }
 
-	protected override bool TryParseValueFromString(string value,
-		out TValue result, out string errorMessage)
-	{
-		var success = BindConverter.TryConvertTo<TValue>(
-			value, CultureInfo.CurrentCulture, out var parsedValue);
-		if (success)
-		{
-			result = parsedValue;
-			errorMessage = null;
+    protected override bool TryParseValueFromString(string value,
+        out TValue result, out string errorMessage)
+    {
+        var success = BindConverter.TryConvertTo<TValue>(
+            value, CultureInfo.CurrentCulture, out var parsedValue);
+        if (success)
+        {
+            result = parsedValue;
+            errorMessage = null;
 
-			return true;
-		}
-		else
-		{
-			result = default;
-			errorMessage = $"{FieldIdentifier.FieldName} field isn't valid.";
+            return true;
+        }
+        else
+        {
+            result = default;
+            errorMessage = $"{FieldIdentifier.FieldName} field isn't valid.";
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
@@ -8,170 +8,170 @@
 
 <div class="@displayStyle">
 
-	<div class="row">
+    <div class="row">
 
-		<div class="col-xl-6 col-lg-6">
+        <div class="col-xl-6 col-lg-6">
 
-			<!-- Detections -->
-			<div class="card shadow mb-4">
-				<!-- Card Header - Dropdown -->
-				<div class="card-header py-3">
-					<h6 class="m-0 font-weight-bold text-primary">Detections</h6>
-				</div>
-				<!-- Card Body -->
-				<div class="card-body">
-					<div class="chart-pie pt-4">
-						<canvas id="detectionsChart"></canvas>
-					</div>
-					<div class="mt-4 text-center small">
-						<span class="mr-2">
-							<i class="fas fa-circle text-success"></i> Reviewed
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-danger"></i> Unreviewed
-						</span>
-					</div>
-				</div>
-			</div>
+            <!-- Detections -->
+            <div class="card shadow mb-4">
+                <!-- Card Header - Dropdown -->
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Detections</h6>
+                </div>
+                <!-- Card Body -->
+                <div class="card-body">
+                    <div class="chart-pie pt-4">
+                        <canvas id="detectionsChart"></canvas>
+                    </div>
+                    <div class="mt-4 text-center small">
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-success"></i> Reviewed
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-danger"></i> Unreviewed
+                        </span>
+                    </div>
+                </div>
+            </div>
 
-		</div>
-		<div class="col-xl-6 col-lg-6">
+        </div>
+        <div class="col-xl-6 col-lg-6">
 
-			<!-- Detection Results -->
+            <!-- Detection Results -->
 
-			<div class="card shadow mb-4">
-				<!-- Card Header - Dropdown -->
-				<div class="card-header py-3">
-					<h6 class="m-0 font-weight-bold text-primary">Results</h6>
-				</div>
-				<!-- Card Body -->
-				<div class="card-body">
-					<div class="chart-pie pt-4">
-						<canvas id="detectionResultsChart"></canvas>
-					</div>
-					<div class="mt-4 text-center small">
-						<span class="mr-2">
-							<i class="fas fa-circle text-success"></i> Confirmed
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-danger"></i> False Positives
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-info"></i> Don't Know
-						</span>
-					</div>
-				</div>
+            <div class="card shadow mb-4">
+                <!-- Card Header - Dropdown -->
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Results</h6>
+                </div>
+                <!-- Card Body -->
+                <div class="card-body">
+                    <div class="chart-pie pt-4">
+                        <canvas id="detectionResultsChart"></canvas>
+                    </div>
+                    <div class="mt-4 text-center small">
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-success"></i> Confirmed
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-danger"></i> False Positives
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-info"></i> Don't Know
+                        </span>
+                    </div>
+                </div>
 
-			</div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-12">
-			<div class="card shadow mb-4">
-				<a href="#Tags" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="Tags">
-					<h6 class="m-0 font-weight-bold text-primary">Tags</h6>
-				</a>
-				<div class="collapse" id="Tags">
-					<div class="card-body">
-						<div class="pt-4">
-							@if (metrics != null)
-							{
-								@foreach (var entry in metrics.Tags)
-								{
-									<h5>@entry.Tag</h5>
-									<ul class="list-inline">
-										@foreach (var link in entry.Ids)
-										{
-											<li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
-										}
-									</ul>
-								}
-							}
-						</div>
-					</div>
-				</div>
-			</div>
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow mb-4">
+                <a href="#Tags" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="Tags">
+                    <h6 class="m-0 font-weight-bold text-primary">Tags</h6>
+                </a>
+                <div class="collapse" id="Tags">
+                    <div class="card-body">
+                        <div class="pt-4">
+                            @if (metrics != null)
+                            {
+                                @foreach (var entry in metrics.Tags)
+                                {
+                                    <h5>@entry.Tag</h5>
+                                    <ul class="list-inline">
+                                        @foreach (var link in entry.Ids)
+                                        {
+                                            <li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
+                                        }
+                                    </ul>
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-			<div class="card shadow mb-4">
-				<a href="#confirmedDetectionComments" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="confirmedDetectionComments">
-					<h6 class="m-0 font-weight-bold text-primary">Comments from Confirmed Detections</h6>
-				</a>
-				<div class="collapse" id="confirmedDetectionComments">
-					<div class="card-body">
-						@if (metrics != null)
-						{<ul class="list-group">
-								@foreach (var entry in metrics.ConfirmedComments)
-								{
-									<li class="list-group-item">
-										<div class="row">
-											<div class="col-xs-2 col-md-1">
-												<img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
-											</div>
-											<div class="col-xs-10 col-md-11">
-												<div>
-													<a href="/detections/detection/@entry.Id">@entry.Id</a>
-													<div class="small">
-														<span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
-													</div>
-												</div>
-												<blockquote class="blockquote mb-0">
-													<p class="comments">@entry.Comment</p>
-													<footer class="blockquote-footer">@entry.Moderator</footer>
-												</blockquote>
-											</div>
-										</div>
-									</li>
-								}
-							</ul>
-						}
-					</div>
-				</div>
-			</div>
+            <div class="card shadow mb-4">
+                <a href="#confirmedDetectionComments" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="confirmedDetectionComments">
+                    <h6 class="m-0 font-weight-bold text-primary">Comments from Confirmed Detections</h6>
+                </a>
+                <div class="collapse" id="confirmedDetectionComments">
+                    <div class="card-body">
+                        @if (metrics != null)
+                        {<ul class="list-group">
+                                @foreach (var entry in metrics.ConfirmedComments)
+                                {
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-xs-2 col-md-1">
+                                                <img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
+                                            </div>
+                                            <div class="col-xs-10 col-md-11">
+                                                <div>
+                                                    <a href="/detections/detection/@entry.Id">@entry.Id</a>
+                                                    <div class="small">
+                                                        <span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
+                                                    </div>
+                                                </div>
+                                                <blockquote class="blockquote mb-0">
+                                                    <p class="comments">@entry.Comment</p>
+                                                    <footer class="blockquote-footer">@entry.Moderator</footer>
+                                                </blockquote>
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                </div>
+            </div>
 
-			<div class="card shadow mb-4">
-				<a href="#falseDetectionComments" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="falseDetectionComments">
-					<h6 class="m-0 font-weight-bold text-primary">Comments from False Positive and Unknown Detections</h6>
-				</a>
-				<div class="collapse" id="falseDetectionComments">
-					<div class="card-body">
-						@if (metrics != null)
-						{<ul class="list-group">
-								@foreach (var entry in metrics.UnconfirmedComments)
-								{
-									<li class="list-group-item">
-										<div class="row">
-											<div class="col-xs-2 col-md-1">
-												<img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
-											</div>
-											<div class="col-xs-10 col-md-11">
-												<div>
-													<a href="/detections/detection/@entry.Id">@entry.Id</a>
-													<div class="small">
-														<span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
-													</div>
-												</div>
-												<blockquote class="blockquote mb-0">
-													<p class="comments">@entry.Comment</p>
-													<footer class="blockquote-footer">@entry.Moderator</footer>
-												</blockquote>
-											</div>
-										</div>
-									</li>
-								}
-							</ul>
-						}
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+            <div class="card shadow mb-4">
+                <a href="#falseDetectionComments" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="falseDetectionComments">
+                    <h6 class="m-0 font-weight-bold text-primary">Comments from False Positive and Unknown Detections</h6>
+                </a>
+                <div class="collapse" id="falseDetectionComments">
+                    <div class="card-body">
+                        @if (metrics != null)
+                        {<ul class="list-group">
+                                @foreach (var entry in metrics.UnconfirmedComments)
+                                {
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-xs-2 col-md-1">
+                                                <img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
+                                            </div>
+                                            <div class="col-xs-10 col-md-11">
+                                                <div>
+                                                    <a href="/detections/detection/@entry.Id">@entry.Id</a>
+                                                    <div class="small">
+                                                        <span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
+                                                    </div>
+                                                </div>
+                                                <blockquote class="blockquote mb-0">
+                                                    <p class="comments">@entry.Comment</p>
+                                                    <footer class="blockquote-footer">@entry.Moderator</footer>
+                                                </blockquote>
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script suppress-error="BL9992" src="vendor/chart.js/Chart.min.js"></script>
@@ -179,88 +179,88 @@
 
 <script suppress-error="BL9992">
 
-	Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';
-	Chart.defaults.global.defaultFontColor = '#858796';
+    Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';
+    Chart.defaults.global.defaultFontColor = '#858796';
 
-	var detectionsChart = null;
-	var detectionsResultChart = null;
+    var detectionsChart = null;
+    var detectionsResultChart = null;
 
-	function DrawDetectionsChart(datasetJson) {
+    function DrawDetectionsChart(datasetJson) {
 
-		if (detectionsChart != null) {
-			detectionsChart.destroy();
-		}
+        if (detectionsChart != null) {
+            detectionsChart.destroy();
+        }
 
-		var ctx = document.getElementById("detectionsChart");
+        var ctx = document.getElementById("detectionsChart");
 
-		detectionsChart = new Chart(ctx, {
-			type: 'doughnut',
-			data: {
-				labels: ["Reviewed", "Unreviewed"],
-				datasets: [{
-					data: JSON.parse(datasetJson),
-					backgroundColor: ['#28a745', '#dc3545'],
-					hoverBackgroundColor: ['#19692c', '#a71d2a'],
-					hoverBorderColor: "rgba(234, 236, 244, 1)",
-				}],
-			},
-			options: {
-				maintainAspectRatio: false,
-				tooltips: {
-					backgroundColor: "rgb(255,255,255)",
-					bodyFontColor: "#858796",
-					borderColor: '#dddfeb',
-					borderWidth: 1,
-					xPadding: 15,
-					yPadding: 15,
-					displayColors: false,
-					caretPadding: 10,
-				},
-				legend: {
-					display: false
-				},
-				cutoutPercentage: 70,
-			},
-		});
-	}
+        detectionsChart = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ["Reviewed", "Unreviewed"],
+                datasets: [{
+                    data: JSON.parse(datasetJson),
+                    backgroundColor: ['#28a745', '#dc3545'],
+                    hoverBackgroundColor: ['#19692c', '#a71d2a'],
+                    hoverBorderColor: "rgba(234, 236, 244, 1)",
+                }],
+            },
+            options: {
+                maintainAspectRatio: false,
+                tooltips: {
+                    backgroundColor: "rgb(255,255,255)",
+                    bodyFontColor: "#858796",
+                    borderColor: '#dddfeb',
+                    borderWidth: 1,
+                    xPadding: 15,
+                    yPadding: 15,
+                    displayColors: false,
+                    caretPadding: 10,
+                },
+                legend: {
+                    display: false
+                },
+                cutoutPercentage: 70,
+            },
+        });
+    }
 
-	function DrawDetectionResultsChart(datasetJson) {
+    function DrawDetectionResultsChart(datasetJson) {
 
-		if (detectionsResultChart != null) {
-			detectionsResultChart.destroy();
-		}
+        if (detectionsResultChart != null) {
+            detectionsResultChart.destroy();
+        }
 
-		var ctx = document.getElementById("detectionResultsChart");
-		detectionsResultChart = new Chart(ctx, {
-			type: 'doughnut',
-			data: {
-				labels: ["Confirmed", "False Positive", "Don't Know"],
-				datasets: [{
-					data: JSON.parse(datasetJson),
-					backgroundColor: ['#28a745', '#dc3545', '#17a2b8'],
-					hoverBackgroundColor: ['#19692c', '#a71d2a', '#0f6674'],
-					hoverBorderColor: "rgba(234, 236, 244, 1)",
-				}],
-			},
-			options: {
-				maintainAspectRatio: false,
-				tooltips: {
-					backgroundColor: "rgb(255,255,255)",
-					bodyFontColor: "#858796",
-					borderColor: '#dddfeb',
-					borderWidth: 1,
-					xPadding: 15,
-					yPadding: 15,
-					displayColors: false,
-					caretPadding: 10,
-				},
-				legend: {
-					display: false
-				},
-				cutoutPercentage: 70,
-			},
-		});
-	}
+        var ctx = document.getElementById("detectionResultsChart");
+        detectionsResultChart = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ["Confirmed", "False Positive", "Don't Know"],
+                datasets: [{
+                    data: JSON.parse(datasetJson),
+                    backgroundColor: ['#28a745', '#dc3545', '#17a2b8'],
+                    hoverBackgroundColor: ['#19692c', '#a71d2a', '#0f6674'],
+                    hoverBorderColor: "rgba(234, 236, 244, 1)",
+                }],
+            },
+            options: {
+                maintainAspectRatio: false,
+                tooltips: {
+                    backgroundColor: "rgb(255,255,255)",
+                    bodyFontColor: "#858796",
+                    borderColor: '#dddfeb',
+                    borderWidth: 1,
+                    xPadding: 15,
+                    yPadding: 15,
+                    displayColors: false,
+                    caretPadding: 10,
+                },
+                legend: {
+                    display: false
+                },
+                cutoutPercentage: 70,
+            },
+        });
+    }
 </script>
 
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
@@ -2,55 +2,55 @@
 
 public partial class Dashboard
 {
-	[Inject]
-	IMetricsService Service { get; set; }
+    [Inject]
+    IMetricsService Service { get; set; }
 
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	private Metrics metrics = null;
+    private Metrics metrics = null;
 
-	private MetricsFilterDTO filterOptions =
-		new MetricsFilterDTO() { Timeframe = "1m" };
+    private MetricsFilterDTO filterOptions =
+        new MetricsFilterDTO() { Timeframe = "1m" };
 
-	private string messageStyle = "d-none";
-	private string message = string.Empty;
-	private string displayStyle = "d-none";
+    private string messageStyle = "d-none";
+    private string message = string.Empty;
+    private string displayStyle = "d-none";
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadMetrics();
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadMetrics();
+    }
 
-	private async Task LoadMetrics()
-	{
-		displayStyle = "d-none";
-		messageStyle = "";
-		message = "Loading metrics...";
+    private async Task LoadMetrics()
+    {
+        displayStyle = "d-none";
+        messageStyle = "";
+        message = "Loading metrics...";
 
-		metrics = await Service.GetSiteMetricsAsync(filterOptions);
+        metrics = await Service.GetSiteMetricsAsync(filterOptions);
 
-		if(!metrics.HasContent)
-		{
-			message = "No metrics found for the selected filter options. Please select a different set of filter options...";
-			displayStyle = "d-none";
-		}
-		else
-		{
-			messageStyle = "d-none";
-			displayStyle = "";
-		}
+        if (!metrics.HasContent)
+        {
+            message = "No metrics found for the selected filter options. Please select a different set of filter options...";
+            displayStyle = "d-none";
+        }
+        else
+        {
+            messageStyle = "d-none";
+            displayStyle = "";
+        }
 
-		StateHasChanged();
+        StateHasChanged();
 
-		await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
-		await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
-	}
+        await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
+        await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+    }
 
-	private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)
-	{
-		filterOptions = returnedFilterOptions;
-		await LoadMetrics();
-	}
+    private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)
+    {
+        filterOptions = returnedFilterOptions;
+        await LoadMetrics();
+    }
 
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor
@@ -5,15 +5,15 @@
 
 <!-- Filter -->
 <CandidateFilterComponent FilterOptions=@filterOptions
-						  ApplyFilterCallback="ActOnApplyFilterCallback" />
+                          ApplyFilterCallback="ActOnApplyFilterCallback" />
 
 @if (loadStatus != null)
 {
-	<h5 class="mt-5">@loadStatus</h5>
+    <h5 class="mt-5">@loadStatus</h5>
 }
 else
 {
-	<!-- Pagination -->
+    <!-- Pagination -->
         @if (detections != null && detections.Count > 0)
         {
                 <div class="col-12 text-left px-0">
@@ -23,22 +23,22 @@ else
                 </div>
         }
 
-	<!-- Cards -->
-	@for (var i = 0; i < detections.Count(); i++)
-	{
-		<DetectionComponent SubmitCallback="ActOnSubmitCallback"
-							Detection=@detections[i] />
-	}
+    <!-- Cards -->
+    @for (var i = 0; i < detections.Count(); i++)
+    {
+        <DetectionComponent SubmitCallback="ActOnSubmitCallback"
+                            Detection=@detections[i] />
+    }
 }
 
 <!-- Pagination -->
 @if (detections != null && detections.Count > 0)
 {
-	<div class="col-12 text-left px-0">
-		<PaginationComponent PaginationOptions=@paginationOptions
-							 PaginationResults="@pagination"
-							 SelectPageCallback="ActOnSelectPageCallback" />
-	</div>
+    <div class="col-12 text-left px-0">
+        <PaginationComponent PaginationOptions=@paginationOptions
+                             PaginationResults="@pagination"
+                             SelectPageCallback="ActOnSelectPageCallback" />
+    </div>
 }
 
 <LoginWarningComponent />

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -2,111 +2,111 @@
 
 public partial class Candidates : IDisposable
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IDetectionService Service { get; set; }
+    [Inject]
+    IDetectionService Service { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	private string _userId;
-	private List<Detection> detections = null;
+    private string _userId;
+    private List<Detection> detections = null;
 
-	private PaginationOptionsDTO paginationOptions = 
-		new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
+    private PaginationOptionsDTO paginationOptions =
+        new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
 
-	private CandidateFilterOptionsDTO filterOptions =
-		new CandidateFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "6h", Location = "all", HydrophoneId = "all" };
+    private CandidateFilterOptionsDTO filterOptions =
+        new CandidateFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "6h", Location = "all", HydrophoneId = "all" };
 
-	private PaginationResultsDTO pagination = new PaginationResultsDTO();
+    private PaginationResultsDTO pagination = new PaginationResultsDTO();
 
-	private string loadStatus = null;
+    private string loadStatus = null;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadDetections();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDetections();
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
-	}
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
+    }
 
-	private async Task LoadDetections()
-	{
-		loadStatus = "Loading records...";
-		detections = null;
-		var paginatedResponse = await Service.GetCandidateDetectionsAsync(paginationOptions, filterOptions);
+    private async Task LoadDetections()
+    {
+        loadStatus = "Loading records...";
+        detections = null;
+        var paginatedResponse = await Service.GetCandidateDetectionsAsync(paginationOptions, filterOptions);
 
-		pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
-		pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+        pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
 
-		// The page we requested may no longer exist.
-		// Clamp to the actual last valid page. re-fetch to render real data
-		if (pagination.TotalNumberOfPages > 0 && paginationOptions.Page > pagination.TotalNumberOfPages)
-		{
-			paginationOptions.Page = pagination.TotalNumberOfPages;
-			paginatedResponse = await Service.GetCandidateDetectionsAsync(paginationOptions, filterOptions);
-			pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
-			pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
-		}
-		pagination.CurrentPage = paginationOptions.Page;
+        // The page we requested may no longer exist.
+        // Clamp to the actual last valid page. re-fetch to render real data
+        if (pagination.TotalNumberOfPages > 0 && paginationOptions.Page > pagination.TotalNumberOfPages)
+        {
+            paginationOptions.Page = pagination.TotalNumberOfPages;
+            paginatedResponse = await Service.GetCandidateDetectionsAsync(paginationOptions, filterOptions);
+            pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+            pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        }
+        pagination.CurrentPage = paginationOptions.Page;
 
-		if (paginatedResponse.Response == null)
-			loadStatus = "An unknown error occurred while loading records...";
-		else if (paginatedResponse.Response.Count == 0)
-		{
-			loadStatus = pagination.TotalNumberOfRecords == 0
-				? "You're caught up, no records match the selected filter options..."
-				: "No records found for the selected filter options. Please select a different set of filter options...";
-		}
-		else
-		{
-			loadStatus = null;
-			detections = paginatedResponse.Response;
-		}
-	}
+        if (paginatedResponse.Response == null)
+            loadStatus = "An unknown error occurred while loading records...";
+        else if (paginatedResponse.Response.Count == 0)
+        {
+            loadStatus = pagination.TotalNumberOfRecords == 0
+                ? "You're caught up, no records match the selected filter options..."
+                : "No records found for the selected filter options. Please select a different set of filter options...";
+        }
+        else
+        {
+            loadStatus = null;
+            detections = paginatedResponse.Response;
+        }
+    }
 
-	private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
-	{
-		paginationOptions = returnedPaginationOptions;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
+    {
+        paginationOptions = returnedPaginationOptions;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnApplyFilterCallback(CandidateFilterOptionsDTO returnedFilterOptions)
-	{
-		filterOptions = returnedFilterOptions;
-		paginationOptions.Page = 1;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnApplyFilterCallback(CandidateFilterOptionsDTO returnedFilterOptions)
+    {
+        filterOptions = returnedFilterOptions;
+        paginationOptions.Page = 1;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnSubmitCallback(DetectionUpdate request)
-	{
-		await Service.UpdateRequestAsync(request);
+    private async Task ActOnSubmitCallback(DetectionUpdate request)
+    {
+        await Service.UpdateRequestAsync(request);
 
-		List<string> leafTags = Detection.GetLeafTags(request.Tags);
-		TagCache.SetTags(_userId, leafTags);
+        List<string> leafTags = Detection.GetLeafTags(request.Tags);
+        TagCache.SetTags(_userId, leafTags);
 
-		ToastService.ShowSuccess("Detection successfully updated.");
+        ToastService.ShowSuccess("Detection successfully updated.");
 
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		await LoadDetections();
-	}
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        await LoadDetections();
+    }
 
-	void IDisposable.Dispose()
-	{
-		JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    void IDisposable.Dispose()
+    {
+        JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor
@@ -4,38 +4,38 @@
 
 <!-- Filter -->
 <ReviewedFilterComponent FilterOptions=@filterOptions
-						 ApplyFilterCallback="ActOnApplyFilterCallback" />
+                         ApplyFilterCallback="ActOnApplyFilterCallback" />
 
 @if (loadStatus != null)
 {
-	<h5 class="mt-5">@loadStatus</h5>
+    <h5 class="mt-5">@loadStatus</h5>
 }
 else
 {
-	<!-- Pagination -->
-	@if (detections != null && detections.Count > 0)
-	{
-		<div class="col-12 text-left px-0">
-			<PaginationComponent PaginationOptions=@paginationOptions
-								PaginationResults="@pagination"
-								SelectPageCallback="ActOnSelectPageCallback" />
-		</div>
-	}
+    <!-- Pagination -->
+    @if (detections != null && detections.Count > 0)
+    {
+        <div class="col-12 text-left px-0">
+            <PaginationComponent PaginationOptions=@paginationOptions
+                                PaginationResults="@pagination"
+                                SelectPageCallback="ActOnSelectPageCallback" />
+        </div>
+    }
 
-	<!-- Cards -->
-	@for (var i = 0; i < detections.Count(); i++)
-	{
-		<DetectionComponent SubmitCallback="ActOnSubmitCallback" Detection=@detections[i] />
-	}
+    <!-- Cards -->
+    @for (var i = 0; i < detections.Count(); i++)
+    {
+        <DetectionComponent SubmitCallback="ActOnSubmitCallback" Detection=@detections[i] />
+    }
 }
 
 
 <!-- Pagination -->
 @if (detections != null && detections.Count > 0)
 {
-	<div class="col-12 text-left px-0">
-		<PaginationComponent PaginationOptions=@paginationOptions
-							 PaginationResults="@pagination"
-							 SelectPageCallback="ActOnSelectPageCallback" />
-	</div>
+    <div class="col-12 text-left px-0">
+        <PaginationComponent PaginationOptions=@paginationOptions
+                             PaginationResults="@pagination"
+                             SelectPageCallback="ActOnSelectPageCallback" />
+    </div>
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
@@ -2,94 +2,94 @@
 
 public partial class Confirmed : IDisposable
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IDetectionService Service { get; set; }
+    [Inject]
+    IDetectionService Service { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	private string _userId;
-	private List<Detection> detections = null;
+    private string _userId;
+    private List<Detection> detections = null;
 
-	private PaginationOptionsDTO paginationOptions =
-		new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
+    private PaginationOptionsDTO paginationOptions =
+        new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
 
-	private ReviewedFilterOptionsDTO filterOptions =
-		new ReviewedFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all" };
+    private ReviewedFilterOptionsDTO filterOptions =
+        new ReviewedFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all" };
 
-	private PaginationResultsDTO pagination = new PaginationResultsDTO();
+    private PaginationResultsDTO pagination = new PaginationResultsDTO();
 
-	private string loadStatus = null;
+    private string loadStatus = null;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadDetections();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDetections();
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
-	}
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
+    }
 
-	private async Task LoadDetections()
-	{
-		loadStatus = "Loading records...";
-		var paginatedResponse = await Service.GetConfirmedDetectionsAsync(paginationOptions, filterOptions);
+    private async Task LoadDetections()
+    {
+        loadStatus = "Loading records...";
+        var paginatedResponse = await Service.GetConfirmedDetectionsAsync(paginationOptions, filterOptions);
 
-		pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
-		pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
-		pagination.CurrentPage = paginationOptions.Page;
+        pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+        pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        pagination.CurrentPage = paginationOptions.Page;
 
-		if (paginatedResponse.Response == null)
-			loadStatus = "An unknown error occurred while loading records...";
-		else if (paginatedResponse.Response.Count == 0)
-			loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
-		else
-		{
-			loadStatus = null;
-			detections = paginatedResponse.Response;
-		}
-	}
-	private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
-	{
-		paginationOptions = returnedPaginationOptions;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+        if (paginatedResponse.Response == null)
+            loadStatus = "An unknown error occurred while loading records...";
+        else if (paginatedResponse.Response.Count == 0)
+            loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        else
+        {
+            loadStatus = null;
+            detections = paginatedResponse.Response;
+        }
+    }
+    private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
+    {
+        paginationOptions = returnedPaginationOptions;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnSubmitCallback(DetectionUpdate request)
-	{
-		await Service.UpdateRequestAsync(request);
+    private async Task ActOnSubmitCallback(DetectionUpdate request)
+    {
+        await Service.UpdateRequestAsync(request);
 
-		List<string> leafTags = Detection.GetLeafTags(request.Tags);
-		TagCache.SetTags(_userId, leafTags);
+        List<string> leafTags = Detection.GetLeafTags(request.Tags);
+        TagCache.SetTags(_userId, leafTags);
 
-		ToastService.ShowSuccess("Detection successfully updated.");
+        ToastService.ShowSuccess("Detection successfully updated.");
 
-		await LoadDetections();
-	}
+        await LoadDetections();
+    }
 
-	private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
-	{
-		filterOptions = returnedFilterOptions;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
+    {
+        filterOptions = returnedFilterOptions;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	void IDisposable.Dispose()
-	{
-		JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    void IDisposable.Dispose()
+    {
+        JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
@@ -2,96 +2,96 @@
 
 public partial class FalsePositives : IDisposable
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IDetectionService Service { get; set; }
+    [Inject]
+    IDetectionService Service { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	private string _userId;
-	private List<Detection> detections = null;
+    private string _userId;
+    private List<Detection> detections = null;
 
-	private PaginationOptionsDTO paginationOptions =
-		new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
+    private PaginationOptionsDTO paginationOptions =
+        new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
 
-	private ReviewedFilterOptionsDTO filterOptions =
-		new ReviewedFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all" };
+    private ReviewedFilterOptionsDTO filterOptions =
+        new ReviewedFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all" };
 
-	private PaginationResultsDTO pagination = new PaginationResultsDTO();
+    private PaginationResultsDTO pagination = new PaginationResultsDTO();
 
-	private string loadStatus = null;
+    private string loadStatus = null;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadDetections();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDetections();
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
-	}
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
+    }
 
-	private async Task LoadDetections()
-	{
-		loadStatus = "Loading records...";
-		var paginatedResponse = await Service.GetFalseDetectionsAsync(paginationOptions, filterOptions);
+    private async Task LoadDetections()
+    {
+        loadStatus = "Loading records...";
+        var paginatedResponse = await Service.GetFalseDetectionsAsync(paginationOptions, filterOptions);
 
-		pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
-		pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
-		pagination.CurrentPage = paginationOptions.Page;
+        pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+        pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        pagination.CurrentPage = paginationOptions.Page;
 
-		if (paginatedResponse.Response == null)
-			loadStatus = "An unknown error occurred while loading records...";
-		else if (paginatedResponse.Response.Count == 0)
-			loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
-		else
-		{
-			loadStatus = null;
-			detections = paginatedResponse.Response;
-		}
-	}
+        if (paginatedResponse.Response == null)
+            loadStatus = "An unknown error occurred while loading records...";
+        else if (paginatedResponse.Response.Count == 0)
+            loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        else
+        {
+            loadStatus = null;
+            detections = paginatedResponse.Response;
+        }
+    }
 
-	private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
-	{
-		paginationOptions = returnedPaginationOptions;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
+    {
+        paginationOptions = returnedPaginationOptions;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
-	{
-		filterOptions = returnedFilterOptions;
-		paginationOptions.Page = 1;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
+    {
+        filterOptions = returnedFilterOptions;
+        paginationOptions.Page = 1;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnSubmitCallback(DetectionUpdate request)
-	{
-		await Service.UpdateRequestAsync(request);
+    private async Task ActOnSubmitCallback(DetectionUpdate request)
+    {
+        await Service.UpdateRequestAsync(request);
 
-		List<string> leafTags = Detection.GetLeafTags(request.Tags);
-		TagCache.SetTags(_userId, leafTags);
+        List<string> leafTags = Detection.GetLeafTags(request.Tags);
+        TagCache.SetTags(_userId, leafTags);
 
-		ToastService.ShowSuccess("Detection successfully updated.");
+        ToastService.ShowSuccess("Detection successfully updated.");
 
-		await LoadDetections();
-	}
+        await LoadDetections();
+    }
 
-	void IDisposable.Dispose()
-	{
-		JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    void IDisposable.Dispose()
+    {
+        JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor
@@ -5,19 +5,19 @@
 
 @if (isUnavailable)
 {
-	<h5 class="mt-5">An unknown error occurred while loading the record...</h5>
+    <h5 class="mt-5">An unknown error occurred while loading the record...</h5>
 }
 else if (detection == null)
 {
-	<h5 class="mt-5">Loading record...</h5>
+    <h5 class="mt-5">Loading record...</h5>
 }
 else if (isFound)
 {
-	<DetectionComponent SubmitCallback="ActOnSubmitCallback" Detection=@detection />
+    <DetectionComponent SubmitCallback="ActOnSubmitCallback" Detection=@detection />
 }
 else
 {
-	<h5 class="mt-5">Requested Detection with ID '@Id' could not be found.</h5>
+    <h5 class="mt-5">Requested Detection with ID '@Id' could not be found.</h5>
 }
 
 <LoginWarningComponent />

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
@@ -2,60 +2,60 @@
 
 public partial class SingleDetection : ComponentBase, IDisposable
 {
-	[Parameter]
-	public string Id { get; set; }
+    [Parameter]
+    public string Id { get; set; }
 
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IDetectionService Service { get; set; }
+    [Inject]
+    IDetectionService Service { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	private string _userId;
-	private Detection detection = null;
-	private bool isFound = true;
-	private bool isUnavailable = false;
+    private string _userId;
+    private Detection detection = null;
+    private bool isFound = true;
+    private bool isUnavailable = false;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadDetection();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDetection();
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
-	}
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
+    }
 
-	private async Task LoadDetection()
-	{
-		detection = await Service.GetDetectionAsync(Id);
-		isUnavailable = detection == null;
-		if (!isUnavailable && detection.Id == null)
-			isFound = false;
-	}
+    private async Task LoadDetection()
+    {
+        detection = await Service.GetDetectionAsync(Id);
+        isUnavailable = detection == null;
+        if (!isUnavailable && detection.Id == null)
+            isFound = false;
+    }
 
-	private async Task ActOnSubmitCallback(DetectionUpdate request)
-	{
-		await Service.UpdateRequestAsync(request);
+    private async Task ActOnSubmitCallback(DetectionUpdate request)
+    {
+        await Service.UpdateRequestAsync(request);
 
-		List<string> leafTags = Detection.GetLeafTags(request.Tags);
-		TagCache.SetTags(_userId, leafTags);
+        List<string> leafTags = Detection.GetLeafTags(request.Tags);
+        TagCache.SetTags(_userId, leafTags);
 
-		ToastService.ShowSuccess("Detection successfully updated.");
+        ToastService.ShowSuccess("Detection successfully updated.");
 
-		await LoadDetection();
-	}
+        await LoadDetection();
+    }
 
-	void IDisposable.Dispose()
-	{
-		JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    void IDisposable.Dispose()
+    {
+        JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor
@@ -4,40 +4,40 @@
 
 <!-- Filter -->
 <CandidateFilterComponent FilterOptions=@filterOptions
-						  ApplyFilterCallback="ActOnApplyFilterCallback" />
+                          ApplyFilterCallback="ActOnApplyFilterCallback" />
 
 @if (loadStatus != null)
 {
-	<h5 class="mt-5">@loadStatus</h5>
+    <h5 class="mt-5">@loadStatus</h5>
 }
 else
 {
-	<!-- Pagination -->
-	@if (detections != null && detections.Count > 0)
-	{
-		<div class="col-12 text-left px-0">
-			<PaginationComponent PaginationOptions=@paginationOptions
-								PaginationResults="@pagination"
-								SelectPageCallback="ActOnSelectPageCallback" />
-		</div>
-	}
+    <!-- Pagination -->
+    @if (detections != null && detections.Count > 0)
+    {
+        <div class="col-12 text-left px-0">
+            <PaginationComponent PaginationOptions=@paginationOptions
+                                PaginationResults="@pagination"
+                                SelectPageCallback="ActOnSelectPageCallback" />
+        </div>
+    }
 
-	<!-- Cards -->
-	@for (var i = 0; i < detections.Count(); i++)
-	{
-		<DetectionComponent SubmitCallback="ActOnSubmitCallback"
-							Detection=@detections[i] />
-	}
+    <!-- Cards -->
+    @for (var i = 0; i < detections.Count(); i++)
+    {
+        <DetectionComponent SubmitCallback="ActOnSubmitCallback"
+                            Detection=@detections[i] />
+    }
 }
 
 <!-- Pagination -->
 @if (detections != null && detections.Count > 0)
 {
-	<div class="col-12 text-left px-0">
-		<PaginationComponent PaginationOptions=@paginationOptions
-							 PaginationResults="@pagination"
-							 SelectPageCallback="ActOnSelectPageCallback" />
-	</div>
+    <div class="col-12 text-left px-0">
+        <PaginationComponent PaginationOptions=@paginationOptions
+                             PaginationResults="@pagination"
+                             SelectPageCallback="ActOnSelectPageCallback" />
+    </div>
 }
 
 <LoginWarningComponent />

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
@@ -2,96 +2,96 @@
 
 public partial class Unknown : IDisposable
 {
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	IDetectionService Service { get; set; }
+    [Inject]
+    IDetectionService Service { get; set; }
 
-	[Inject]
-	IToastService ToastService { get; set; }
+    [Inject]
+    IToastService ToastService { get; set; }
 
-	[Inject]
-	UserTagCache TagCache { get; set; }
+    [Inject]
+    UserTagCache TagCache { get; set; }
 
-	[Inject]
-	AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    [Inject]
+    AuthenticationStateProvider AuthenticationStateProvider { get; set; }
 
-	private string _userId;
-	private List<Detection> detections = null;
+    private string _userId;
+    private List<Detection> detections = null;
 
-	private PaginationOptionsDTO paginationOptions =
-		new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
+    private PaginationOptionsDTO paginationOptions =
+        new PaginationOptionsDTO() { RecordsPerPage = 5, Page = 1 };
 
-	private CandidateFilterOptionsDTO filterOptions =
-		new CandidateFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all", HydrophoneId = "all" };
+    private CandidateFilterOptionsDTO filterOptions =
+        new CandidateFilterOptionsDTO() { SortBy = "timestamp", SortOrder = "desc", Timeframe = "24h", Location = "all", HydrophoneId = "all" };
 
-	private PaginationResultsDTO pagination = new PaginationResultsDTO();
+    private PaginationResultsDTO pagination = new PaginationResultsDTO();
 
-	private string loadStatus = null;
+    private string loadStatus = null;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadDetections();
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDetections();
 
-		var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-		var user = authState.User;
-		_userId = user.FindFirst("oid")?.Value;
-	}
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _userId = user.FindFirst("oid")?.Value;
+    }
 
-	private async Task LoadDetections()
-	{
-		loadStatus = "Loading records...";
-		var paginatedResponse = await Service.GetUnconfirmedDetectionsAsync(paginationOptions, filterOptions);
+    private async Task LoadDetections()
+    {
+        loadStatus = "Loading records...";
+        var paginatedResponse = await Service.GetUnconfirmedDetectionsAsync(paginationOptions, filterOptions);
 
-		pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
-		pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
-		pagination.CurrentPage = paginationOptions.Page;
+        pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+        pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        pagination.CurrentPage = paginationOptions.Page;
 
-		if (paginatedResponse.Response == null)
-			loadStatus = "An unknown error occurred while loading records...";
-		else if (paginatedResponse.Response.Count == 0)
-			loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
-		else
-		{
-			loadStatus = null;
-			detections = paginatedResponse.Response;
-		}
-	}
+        if (paginatedResponse.Response == null)
+            loadStatus = "An unknown error occurred while loading records...";
+        else if (paginatedResponse.Response.Count == 0)
+            loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        else
+        {
+            loadStatus = null;
+            detections = paginatedResponse.Response;
+        }
+    }
 
-	private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
-	{
-		paginationOptions = returnedPaginationOptions;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
+    {
+        paginationOptions = returnedPaginationOptions;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnApplyFilterCallback(CandidateFilterOptionsDTO returnedFilterOptions)
-	{
-		filterOptions = returnedFilterOptions;
-		paginationOptions.Page = 1;
-		detections = null;
-		await LoadDetections();
-		await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-		StateHasChanged();
-	}
+    private async Task ActOnApplyFilterCallback(CandidateFilterOptionsDTO returnedFilterOptions)
+    {
+        filterOptions = returnedFilterOptions;
+        paginationOptions.Page = 1;
+        detections = null;
+        await LoadDetections();
+        await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+        StateHasChanged();
+    }
 
-	private async Task ActOnSubmitCallback(DetectionUpdate request)
-	{
-		await Service.UpdateRequestAsync(request);
+    private async Task ActOnSubmitCallback(DetectionUpdate request)
+    {
+        await Service.UpdateRequestAsync(request);
 
-		List<string> leafTags = Detection.GetLeafTags(request.Tags);
-		TagCache.SetTags(_userId, leafTags);
+        List<string> leafTags = Detection.GetLeafTags(request.Tags);
+        TagCache.SetTags(_userId, leafTags);
 
-		ToastService.ShowSuccess("Detection successfully updated.");
+        ToastService.ShowSuccess("Detection successfully updated.");
 
-		await LoadDetections();
-	}
+        await LoadDetections();
+    }
 
-	void IDisposable.Dispose()
-	{
-		JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
-	}
+    void IDisposable.Dispose()
+    {
+        JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor
@@ -4,35 +4,35 @@
 <link rel="stylesheet" href="@darkTheme" />
 
 <div id="page-top">
-	<!-- Page Wrapper -->
-	<div id="wrapper">
+    <!-- Page Wrapper -->
+    <div id="wrapper">
 
-		<SideBarComponent />
+        <SideBarComponent />
 
-		<!-- Content Wrapper -->
-		<div id="content-wrapper" class="d-flex flex-column">
+        <!-- Content Wrapper -->
+        <div id="content-wrapper" class="d-flex flex-column">
 
-			<!-- Main Content -->
-			<div id="content">
+            <!-- Main Content -->
+            <div id="content">
 
-				<TopBarComponent ToggleThemeCallback="ActOnToggleThemeCallback" CurrentUrl="@CurrentUrl" />
+                <TopBarComponent ToggleThemeCallback="ActOnToggleThemeCallback" CurrentUrl="@CurrentUrl" />
 
-				<!-- Begin Page Content -->
-				<div class="container-fluid">
-					@Body
-				</div>
-			</div>
+                <!-- Begin Page Content -->
+                <div class="container-fluid">
+                    @Body
+                </div>
+            </div>
 
-		</div>
-		<!-- End of Content Wrapper-->
-	</div>
-	<!-- End of Page Wrapper -->
-	<!-- Scroll to Top Button-->
-	<a class="scroll-to-top rounded" href="#page-top">
-		<i class="fas fa-angle-up"></i>
-	</a>
+        </div>
+        <!-- End of Content Wrapper-->
+    </div>
+    <!-- End of Page Wrapper -->
+    <!-- Scroll to Top Button-->
+    <a class="scroll-to-top rounded" href="#page-top">
+        <i class="fas fa-angle-up"></i>
+    </a>
 
-	<LogoutComponent />
+    <LogoutComponent />
 </div>
 
 <BlazoredToasts Position="ToastPosition.BottomRight"

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/MainLayout.razor.cs
@@ -2,22 +2,22 @@
 
 public partial class MainLayout
 {
-	string darkTheme = string.Empty;
+    string darkTheme = string.Empty;
 
-	[Inject]
-	NavigationManager Nav { get; set; }
+    [Inject]
+    NavigationManager Nav { get; set; }
 
-	private string CurrentUrl;
+    private string CurrentUrl;
 
-	public void ActOnToggleThemeCallback()
-	{
-		darkTheme = string.IsNullOrWhiteSpace(darkTheme) ? "css/sb-admin-2-dark.css" : "";
-		StateHasChanged();
-	}
+    public void ActOnToggleThemeCallback()
+    {
+        darkTheme = string.IsNullOrWhiteSpace(darkTheme) ? "css/sb-admin-2-dark.css" : "";
+        StateHasChanged();
+    }
 
-	protected override void OnAfterRender(bool firstRender)
-	{
-		CurrentUrl = Nav.Uri;
-		StateHasChanged();
-	}
+    protected override void OnAfterRender(bool firstRender)
+    {
+        CurrentUrl = Nav.Uri;
+        StateHasChanged();
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
@@ -3,176 +3,176 @@
 <PageHeadingComponent Title="My Activities" />
 
 <MetricsFilterComponent FilterOptions=@filterOptions
-						ApplyFilterCallback="ActOnApplyFilterCallback" />
+                        ApplyFilterCallback="ActOnApplyFilterCallback" />
 
 <h5 class="mt-5 @messageStyle">@message</h5>
 
 <div class="@displayStyle">
 
-	<div class="row">
+    <div class="row">
 
-		<div class="col-xl-6 col-lg-6">
+        <div class="col-xl-6 col-lg-6">
 
-			<!-- Detections -->
-			<div class="card shadow mb-4">
-				<!-- Card Header - Dropdown -->
-				<div class="card-header py-3">
-					<h6 class="m-0 font-weight-bold text-primary">Detections</h6>
-				</div>
-				<!-- Card Body -->
-				<div class="card-body">
-					<div class="chart-pie pt-4">
-						<canvas id="detectionsChart"></canvas>
-					</div>
-					<div class="mt-4 text-center small">
-						<span class="mr-2">
-							<i class="fas fa-circle text-success"></i> Reviewed
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-danger"></i> Unreviewed
-						</span>
-					</div>
-				</div>
-			</div>
+            <!-- Detections -->
+            <div class="card shadow mb-4">
+                <!-- Card Header - Dropdown -->
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Detections</h6>
+                </div>
+                <!-- Card Body -->
+                <div class="card-body">
+                    <div class="chart-pie pt-4">
+                        <canvas id="detectionsChart"></canvas>
+                    </div>
+                    <div class="mt-4 text-center small">
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-success"></i> Reviewed
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-danger"></i> Unreviewed
+                        </span>
+                    </div>
+                </div>
+            </div>
 
-		</div>
-		<div class="col-xl-6 col-lg-6">
+        </div>
+        <div class="col-xl-6 col-lg-6">
 
-			<!-- Detection Results -->
+            <!-- Detection Results -->
 
-			<div class="card shadow mb-4">
-				<!-- Card Header - Dropdown -->
-				<div class="card-header py-3">
-					<h6 class="m-0 font-weight-bold text-primary">Results</h6>
-				</div>
-				<!-- Card Body -->
-				<div class="card-body">
-					<div class="chart-pie pt-4">
-						<canvas id="detectionResultsChart"></canvas>
-					</div>
-					<div class="mt-4 text-center small">
-						<span class="mr-2">
-							<i class="fas fa-circle text-success"></i> Confirmed
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-danger"></i> False Positives
-						</span>
-						<span class="mr-2">
-							<i class="fas fa-circle text-info"></i> Don't Know
-						</span>
-					</div>
-				</div>
+            <div class="card shadow mb-4">
+                <!-- Card Header - Dropdown -->
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Results</h6>
+                </div>
+                <!-- Card Body -->
+                <div class="card-body">
+                    <div class="chart-pie pt-4">
+                        <canvas id="detectionResultsChart"></canvas>
+                    </div>
+                    <div class="mt-4 text-center small">
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-success"></i> Confirmed
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-danger"></i> False Positives
+                        </span>
+                        <span class="mr-2">
+                            <i class="fas fa-circle text-info"></i> Don't Know
+                        </span>
+                    </div>
+                </div>
 
-			</div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-12">
-			<div class="card shadow mb-4">
-				<a href="#Tags" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="Tags">
-					<h6 class="m-0 font-weight-bold text-primary">Tags</h6>
-				</a>
-				<div class="collapse" id="Tags">
-					<div class="card-body">
-						<div class="pt-4">
-							@if (metrics != null)
-							{
-								@foreach (var entry in metrics.Tags)
-								{
-									<h5>@entry.Tag</h5>
-									<ul class="list-inline">
-										@foreach (var link in entry.Ids)
-										{
-											<li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
-										}
-									</ul>
-								}
-							}
-						</div>
-					</div>
-				</div>
-			</div>
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow mb-4">
+                <a href="#Tags" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="Tags">
+                    <h6 class="m-0 font-weight-bold text-primary">Tags</h6>
+                </a>
+                <div class="collapse" id="Tags">
+                    <div class="card-body">
+                        <div class="pt-4">
+                            @if (metrics != null)
+                            {
+                                @foreach (var entry in metrics.Tags)
+                                {
+                                    <h5>@entry.Tag</h5>
+                                    <ul class="list-inline">
+                                        @foreach (var link in entry.Ids)
+                                        {
+                                            <li class="list-inline-item"><a href="/detections/detection/@link" target="_blank">@link</a></li>
+                                        }
+                                    </ul>
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-			<div class="card shadow mb-4">
-				<a href="#confirmedDetectionComments" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="confirmedDetectionComments">
-					<h6 class="m-0 font-weight-bold text-primary">Comments from Confirmed Detections</h6>
-				</a>
-				<div class="collapse" id="confirmedDetectionComments">
-					<div class="card-body">
-						@if (metrics != null)
-						{<ul class="list-group">
-								@foreach (var entry in metrics.ConfirmedComments)
-								{
-									<li class="list-group-item">
-										<div class="row">
-											<div class="col-xs-2 col-md-1">
-												<img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
-											</div>
-											<div class="col-xs-10 col-md-11">
-												<div>
-													<a href="/detections/detection/@entry.Id">@entry.Id</a>
-													<div class="small">
-														<span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
-													</div>
-												</div>
-												<blockquote class="blockquote mb-0">
-													<p class="comments">@entry.Comment</p>
-													<footer class="blockquote-footer">@entry.Moderator</footer>
-												</blockquote>
-											</div>
-										</div>
-									</li>
-								}
-							</ul>
-						}
-					</div>
-				</div>
-			</div>
+            <div class="card shadow mb-4">
+                <a href="#confirmedDetectionComments" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="confirmedDetectionComments">
+                    <h6 class="m-0 font-weight-bold text-primary">Comments from Confirmed Detections</h6>
+                </a>
+                <div class="collapse" id="confirmedDetectionComments">
+                    <div class="card-body">
+                        @if (metrics != null)
+                        {<ul class="list-group">
+                                @foreach (var entry in metrics.ConfirmedComments)
+                                {
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-xs-2 col-md-1">
+                                                <img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
+                                            </div>
+                                            <div class="col-xs-10 col-md-11">
+                                                <div>
+                                                    <a href="/detections/detection/@entry.Id">@entry.Id</a>
+                                                    <div class="small">
+                                                        <span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
+                                                    </div>
+                                                </div>
+                                                <blockquote class="blockquote mb-0">
+                                                    <p class="comments">@entry.Comment</p>
+                                                    <footer class="blockquote-footer">@entry.Moderator</footer>
+                                                </blockquote>
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                </div>
+            </div>
 
-			<div class="card shadow mb-4">
-				<a href="#falseDetectionComments" class="d-block card-header py-3 collapsed"
-				   data-toggle="collapse" role="button"
-				   aria-expanded="false" aria-controls="falseDetectionComments">
-					<h6 class="m-0 font-weight-bold text-primary">Comments from False Positive and Unknown Detections</h6>
-				</a>
-				<div class="collapse" id="falseDetectionComments">
-					<div class="card-body">
-						@if (metrics != null)
-						{<ul class="list-group">
-								@foreach (var entry in metrics.UnconfirmedComments)
-								{
-									<li class="list-group-item">
-										<div class="row">
-											<div class="col-xs-2 col-md-1">
-												<img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
-											</div>
-											<div class="col-xs-10 col-md-11">
-												<div>
-													<a href="/detections/detection/@entry.Id">@entry.Id</a>
-													<div class="small">
-														<span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
-													</div>
-												</div>
-												<blockquote class="blockquote mb-0">
-													<p class="comments">@entry.Comment</p>
-													<footer class="blockquote-footer">@entry.Moderator</footer>
-												</blockquote>
-											</div>
-										</div>
-									</li>
-								}
-							</ul>
-						}
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+            <div class="card shadow mb-4">
+                <a href="#falseDetectionComments" class="d-block card-header py-3 collapsed"
+                   data-toggle="collapse" role="button"
+                   aria-expanded="false" aria-controls="falseDetectionComments">
+                    <h6 class="m-0 font-weight-bold text-primary">Comments from False Positive and Unknown Detections</h6>
+                </a>
+                <div class="collapse" id="falseDetectionComments">
+                    <div class="card-body">
+                        @if (metrics != null)
+                        {<ul class="list-group">
+                                @foreach (var entry in metrics.UnconfirmedComments)
+                                {
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-xs-2 col-md-1">
+                                                <img src="/img/comments.png" class="img-fluid" alt="" height="80" width="80" />
+                                            </div>
+                                            <div class="col-xs-10 col-md-11">
+                                                <div>
+                                                    <a href="/detections/detection/@entry.Id">@entry.Id</a>
+                                                    <div class="small">
+                                                        <span class="comments">@DateHelper.UTCToPDTFull(entry.Timestamp)</span><br />
+                                                    </div>
+                                                </div>
+                                                <blockquote class="blockquote mb-0">
+                                                    <p class="comments">@entry.Comment</p>
+                                                    <footer class="blockquote-footer">@entry.Moderator</footer>
+                                                </blockquote>
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script suppress-error="BL9992" src="vendor/chart.js/Chart.min.js"></script>
@@ -180,88 +180,88 @@
 
 <script suppress-error="BL9992">
 
-	Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';
-	Chart.defaults.global.defaultFontColor = '#858796';
+    Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';
+    Chart.defaults.global.defaultFontColor = '#858796';
 
-	var detectionsChart = null;
-	var detectionsResultChart = null;
+    var detectionsChart = null;
+    var detectionsResultChart = null;
 
-	function DrawDetectionsChart(datasetJson) {
+    function DrawDetectionsChart(datasetJson) {
 
-		if (detectionsChart != null) {
-			detectionsChart.destroy();
-		}
+        if (detectionsChart != null) {
+            detectionsChart.destroy();
+        }
 
-		var ctx = document.getElementById("detectionsChart");
+        var ctx = document.getElementById("detectionsChart");
 
-		detections = new Chart(ctx, {
-			type: 'doughnut',
-			data: {
-				labels: ["Reviewed", "Unreviewed"],
-				datasets: [{
-					data: JSON.parse(datasetJson),
-					backgroundColor: ['#28a745', '#dc3545'],
-					hoverBackgroundColor: ['#19692c', '#a71d2a'],
-					hoverBorderColor: "rgba(234, 236, 244, 1)",
-				}],
-			},
-			options: {
-				maintainAspectRatio: false,
-				tooltips: {
-					backgroundColor: "rgb(255,255,255)",
-					bodyFontColor: "#858796",
-					borderColor: '#dddfeb',
-					borderWidth: 1,
-					xPadding: 15,
-					yPadding: 15,
-					displayColors: false,
-					caretPadding: 10,
-				},
-				legend: {
-					display: false
-				},
-				cutoutPercentage: 70,
-			},
-		});
-	}
+        detections = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ["Reviewed", "Unreviewed"],
+                datasets: [{
+                    data: JSON.parse(datasetJson),
+                    backgroundColor: ['#28a745', '#dc3545'],
+                    hoverBackgroundColor: ['#19692c', '#a71d2a'],
+                    hoverBorderColor: "rgba(234, 236, 244, 1)",
+                }],
+            },
+            options: {
+                maintainAspectRatio: false,
+                tooltips: {
+                    backgroundColor: "rgb(255,255,255)",
+                    bodyFontColor: "#858796",
+                    borderColor: '#dddfeb',
+                    borderWidth: 1,
+                    xPadding: 15,
+                    yPadding: 15,
+                    displayColors: false,
+                    caretPadding: 10,
+                },
+                legend: {
+                    display: false
+                },
+                cutoutPercentage: 70,
+            },
+        });
+    }
 
-	function DrawDetectionResultsChart(datasetJson) {
+    function DrawDetectionResultsChart(datasetJson) {
 
-		if (detectionsResultChart != null) {
-			detectionsResultChart.destroy();
-		}
+        if (detectionsResultChart != null) {
+            detectionsResultChart.destroy();
+        }
 
-		var ctx = document.getElementById("detectionResultsChart");
+        var ctx = document.getElementById("detectionResultsChart");
 
-		detectionsResultChart = new Chart(ctx, {
-			type: 'doughnut',
-			data: {
-				labels: ["Confirmed", "False Positive", "Don't Know"],
-				datasets: [{
-					data: JSON.parse(datasetJson),
-					backgroundColor: ['#28a745', '#dc3545', '#17a2b8'],
-					hoverBackgroundColor: ['#19692c', '#a71d2a', '#0f6674'],
-					hoverBorderColor: "rgba(234, 236, 244, 1)",
-				}],
-			},
-			options: {
-				maintainAspectRatio: false,
-				tooltips: {
-					backgroundColor: "rgb(255,255,255)",
-					bodyFontColor: "#858796",
-					borderColor: '#dddfeb',
-					borderWidth: 1,
-					xPadding: 15,
-					yPadding: 15,
-					displayColors: false,
-					caretPadding: 10,
-				},
-				legend: {
-					display: false
-				},
-				cutoutPercentage: 70,
-			},
-		});
-	}
+        detectionsResultChart = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: ["Confirmed", "False Positive", "Don't Know"],
+                datasets: [{
+                    data: JSON.parse(datasetJson),
+                    backgroundColor: ['#28a745', '#dc3545', '#17a2b8'],
+                    hoverBackgroundColor: ['#19692c', '#a71d2a', '#0f6674'],
+                    hoverBorderColor: "rgba(234, 236, 244, 1)",
+                }],
+            },
+            options: {
+                maintainAspectRatio: false,
+                tooltips: {
+                    backgroundColor: "rgb(255,255,255)",
+                    bodyFontColor: "#858796",
+                    borderColor: '#dddfeb',
+                    borderWidth: 1,
+                    xPadding: 15,
+                    yPadding: 15,
+                    displayColors: false,
+                    caretPadding: 10,
+                },
+                legend: {
+                    display: false
+                },
+                cutoutPercentage: 70,
+            },
+        });
+    }
 </script>
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
@@ -2,60 +2,60 @@
 
 public partial class UserActivity
 {
-	[Inject]
-	IMetricsService Service { get; set; }
+    [Inject]
+    IMetricsService Service { get; set; }
 
-	[Inject]
-	IJSRuntime JSRuntime { get; set; }
+    [Inject]
+    IJSRuntime JSRuntime { get; set; }
 
-	[Inject]
-	//AuthenticationStateProvider AuthenticationStateProvider { get; set; }
-	IAccountService AccountService { get; set; }
+    [Inject]
+    //AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    IAccountService AccountService { get; set; }
 
-	private ModeratorMetrics metrics = null;
+    private ModeratorMetrics metrics = null;
 
-	private ModeratorMetricsFilterDTO filterOptions =
-		new ModeratorMetricsFilterDTO() { Timeframe = "1m" };
+    private ModeratorMetricsFilterDTO filterOptions =
+        new ModeratorMetricsFilterDTO() { Timeframe = "1m" };
 
-	private string messageStyle = "d-none";
-	private string message = string.Empty;
-	private string displayStyle = "d-none";
+    private string messageStyle = "d-none";
+    private string message = string.Empty;
+    private string displayStyle = "d-none";
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadMetrics();
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadMetrics();
+    }
 
-	private async Task LoadMetrics()
-	{
-		filterOptions.Moderator = await AccountService.GetUsername();
+    private async Task LoadMetrics()
+    {
+        filterOptions.Moderator = await AccountService.GetUsername();
 
-		displayStyle = "d-none";
-		messageStyle = "";
-		message = "Loading metrics...";
+        displayStyle = "d-none";
+        messageStyle = "";
+        message = "Loading metrics...";
 
-		metrics = await Service.GetModeratorMetricsAsync(filterOptions);
+        metrics = await Service.GetModeratorMetricsAsync(filterOptions);
 
-		if (!metrics.HasContent)
-		{
-			message = "No metrics found for the selected filter options. Please select a different set of filter options...";
-			displayStyle = "d-none";
-		}
-		else
-		{
-			messageStyle = "d-none";
-			displayStyle = "";
-		}
+        if (!metrics.HasContent)
+        {
+            message = "No metrics found for the selected filter options. Please select a different set of filter options...";
+            displayStyle = "d-none";
+        }
+        else
+        {
+            messageStyle = "d-none";
+            displayStyle = "";
+        }
 
-		StateHasChanged();
+        StateHasChanged();
 
-		await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
-		await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
-	}
+        await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
+        await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+    }
 
-	private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)
-	{
-		filterOptions.Timeframe = returnedFilterOptions.Timeframe;
-		await LoadMetrics();
-	}
+    private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)
+    {
+        filterOptions.Timeframe = returnedFilterOptions.Timeframe;
+        await LoadMetrics();
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/AccountService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/AccountService.cs
@@ -94,7 +94,7 @@ public class AccountService : IAccountService
             {
                 await apiProvider.MarkUserAsAuthenticated(token.AccessToken);
             }
-            
+
             _logger.LogInformation("User logged in successfully");
         }
         catch (Exception ex)
@@ -109,9 +109,9 @@ public class AccountService : IAccountService
         {
             apiProvider.MarkUserAsLoggedOut();
         }
-        
+
         _logger.LogInformation("User logged out");
-        
+
         return Task.CompletedTask;
     }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/ApiAuthenticationStateProvider.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/ApiAuthenticationStateProvider.cs
@@ -8,7 +8,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
     private readonly CircuitHandlerService _circuitHandler;
     private readonly ILogger<ApiAuthenticationStateProvider> _logger;
     private ClaimsPrincipal _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
-    
+
     private static int _instanceCount = 0;
     private readonly int _instanceId;
 
@@ -20,7 +20,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
         _tokenStore = tokenStore;
         _circuitHandler = circuitHandler;
         _logger = logger;
-        
+
         _instanceId = Interlocked.Increment(ref _instanceCount);
         _logger.LogDebug("ApiAuthenticationStateProvider Instance #{InstanceId} created", _instanceId);
     }
@@ -28,7 +28,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
     public override Task<AuthenticationState> GetAuthenticationStateAsync()
     {
         _logger.LogDebug("GetAuthenticationStateAsync called on Instance #{InstanceId}", _instanceId);
-        
+
         var circuitId = _circuitHandler.CircuitId;
         if (!string.IsNullOrWhiteSpace(circuitId))
         {
@@ -40,7 +40,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
                 {
                     var claims = ParseClaimsFromJwt(token).ToList();
                     _currentUser = new ClaimsPrincipal(new ClaimsIdentity(claims, "jwt"));
-                    
+
                     _logger.LogDebug("Instance #{InstanceId} - User authenticated from token store", _instanceId);
                 }
                 catch (Exception ex)
@@ -61,14 +61,14 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
             _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
             _logger.LogWarning("Instance #{InstanceId} has no circuit ID; treating user as anonymous", _instanceId);
         }
-        
+
         return Task.FromResult(new AuthenticationState(_currentUser));
     }
 
     public Task MarkUserAsAuthenticated(string token)
     {
         _logger.LogDebug("MarkUserAsAuthenticated called on Instance #{InstanceId}", _instanceId);
-        
+
         if (string.IsNullOrWhiteSpace(token))
         {
             _logger.LogWarning("Attempted to mark user as authenticated with empty token");
@@ -88,15 +88,15 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
 
             // Parse claims and update local state.
             var claims = ParseClaimsFromJwt(token).ToList();
-            
+
             _currentUser = new ClaimsPrincipal(new ClaimsIdentity(claims, "jwt"));
-            
-            _logger.LogDebug("Instance #{InstanceId} - _currentUser.IsAuthenticated = {IsAuth}", 
+
+            _logger.LogDebug("Instance #{InstanceId} - _currentUser.IsAuthenticated = {IsAuth}",
                 _instanceId, _currentUser.Identity?.IsAuthenticated ?? false);
-            
+
             // Notify authentication state changed.
             NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(_currentUser)));
-            
+
             _logger.LogInformation("User authenticated successfully");
         }
         catch (Exception ex)
@@ -110,7 +110,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
     public void MarkUserAsLoggedOut()
     {
         _logger.LogDebug("MarkUserAsLoggedOut called on Instance #{InstanceId}", _instanceId);
-        
+
         var circuitId = _circuitHandler.CircuitId;
         if (!string.IsNullOrWhiteSpace(circuitId))
         {
@@ -118,9 +118,9 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
         }
 
         _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
-        
+
         NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(_currentUser)));
-        
+
         _logger.LogInformation("User logged out");
     }
 
@@ -138,7 +138,7 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
     private IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
     {
         var claims = new List<Claim>();
-        
+
         try
         {
             var payload = jwt.Split('.')[1];

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/UserTagCache.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/UserTagCache.cs
@@ -22,7 +22,7 @@ public class UserTagCache
     {
         if (string.IsNullOrWhiteSpace(userId) || tags == null)
         {
-           return;
+            return;
         }
 
         _cache[userId] = tags.ToList();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Annotation.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Annotation.cs
@@ -1,37 +1,37 @@
 ﻿namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Section within the detection that might contain whale sounds.
-	/// </summary>
-	public class Annotation
-	{
-		/// <summary>
-		/// Unique identifier (within the detection) of the annotation.
-		/// </summary>
-		/// <example>1</example>
-		public int Id { get; set; }
+    /// <summary>
+    /// Section within the detection that might contain whale sounds.
+    /// </summary>
+    public class Annotation
+    {
+        /// <summary>
+        /// Unique identifier (within the detection) of the annotation.
+        /// </summary>
+        /// <example>1</example>
+        public int Id { get; set; }
 
-		/// <summary>
-		/// Start time (within the detection) of the annotation as measured in seconds.
-		/// </summary>
-		/// <example>35</example>
-		public decimal StartTime { get; set; }
+        /// <summary>
+        /// Start time (within the detection) of the annotation as measured in seconds.
+        /// </summary>
+        /// <example>35</example>
+        public decimal StartTime { get; set; }
 
-		/// <summary>
-		/// End time (within the detection) of the annotation as measured in seconds.
-		/// </summary>
-		/// <example>37.5</example>
-		public decimal EndTime { get; set; }
+        /// <summary>
+        /// End time (within the detection) of the annotation as measured in seconds.
+        /// </summary>
+        /// <example>37.5</example>
+        public decimal EndTime { get; set; }
 
-		/// <summary>
-		/// Calculated confidence that the annotation contains a whale sound.
-		/// </summary>
-		/// <example>84.39</example>
-		public decimal Confidence { get; set; }
+        /// <summary>
+        /// Calculated confidence that the annotation contains a whale sound.
+        /// </summary>
+        /// <example>84.39</example>
+        public decimal Confidence { get; set; }
 
-		/// <summary>
-		/// Predicted label, if any.
-		/// </summary>
-		public string Label { get; set; } = string.Empty;
-	}
+        /// <summary>
+        /// Predicted label, if any.
+        /// </summary>
+        public string Label { get; set; } = string.Empty;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
@@ -4,214 +4,214 @@ using System.Linq;
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// A hydrophone sampling that might contain whale sounds.
-	/// </summary>
-	public class Detection
-	{
-		/// <summary>
-		/// The detection's generated unique Id.
-		/// </summary>
-		/// <example>00000000-0000-0000-0000-000000000000</example>
-		public string Id { get; set; }
+    /// <summary>
+    /// A hydrophone sampling that might contain whale sounds.
+    /// </summary>
+    public class Detection
+    {
+        /// <summary>
+        /// The detection's generated unique Id.
+        /// </summary>
+        /// <example>00000000-0000-0000-0000-000000000000</example>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// URI of the detection's audio file (.wav) in blob storage.
-		/// </summary>
-		/// <example>https://storagesite.blob.core.windows.net/audiowavs/audiofilename.wav</example>
-		public string AudioUri { get; set; }
+        /// <summary>
+        /// URI of the detection's audio file (.wav) in blob storage.
+        /// </summary>
+        /// <example>https://storagesite.blob.core.windows.net/audiowavs/audiofilename.wav</example>
+        public string AudioUri { get; set; }
 
-		/// <summary>
-		/// URI of the detection's image file (.png) in blob storage.
-		/// </summary>
-		/// <example>https://storagesite.blob.core.windows.net/spectrogramspng/imagefilename.png</example>
-		public string SpectrogramUri { get; set; }
+        /// <summary>
+        /// URI of the detection's image file (.png) in blob storage.
+        /// </summary>
+        /// <example>https://storagesite.blob.core.windows.net/spectrogramspng/imagefilename.png</example>
+        public string SpectrogramUri { get; set; }
 
-		/// <summary>
-		/// Location of the microphone that collected the detection.
-		/// </summary>
-		public Location Location { get; set; }
+        /// <summary>
+        /// Location of the microphone that collected the detection.
+        /// </summary>
+        public Location Location { get; set; }
 
-		/// <summary>
-		/// Date and time of when the detection occurred.
-		/// </summary>
-		/// <example>2020-09-30T11:03:56.057346Z</example>
-		public DateTime Timestamp { get; set; }
+        /// <summary>
+        /// Date and time of when the detection occurred.
+        /// </summary>
+        /// <example>2020-09-30T11:03:56.057346Z</example>
+        public DateTime Timestamp { get; set; }
 
-		/// <summary>
-		/// List of sections within the detection that might contain whale sounds.
-		/// </summary>
-		public List<Annotation> Annotations { get; set; } = new List<Annotation>();
+        /// <summary>
+        /// List of sections within the detection that might contain whale sounds.
+        /// </summary>
+        public List<Annotation> Annotations { get; set; } = new List<Annotation>();
 
-		/// <summary>
-		/// Flag indicating whether or not the dection has been reviewed by a human moderator.
-		/// </summary>
-		/// <example>true</example>
-		public bool Reviewed { get; set; }
+        /// <summary>
+        /// Flag indicating whether or not the dection has been reviewed by a human moderator.
+        /// </summary>
+        /// <example>true</example>
+        public bool Reviewed { get; set; }
 
-		/// <summary>
-		/// Flag indicating whether the human moderator heard whale sounds in the detection.
-		/// </summary>
-		/// <example>yes</example>
-		public string Found { get; set; }
+        /// <summary>
+        /// Flag indicating whether the human moderator heard whale sounds in the detection.
+        /// </summary>
+        /// <example>yes</example>
+        public string Found { get; set; }
 
-		/// <summary>
-		/// Any text comments entered by the human moderator during review.
-		/// </summary>
-		/// <example>Clear whale sounds detected.</example> 
-		public string Comments { get; set; }
+        /// <summary>
+        /// Any text comments entered by the human moderator during review.
+        /// </summary>
+        /// <example>Clear whale sounds detected.</example> 
+        public string Comments { get; set; }
 
-		/// <summary>
-		/// Calculated average confidence that the detection contains a whale sound.
-		/// </summary>
-		/// <example>84.39</example>
-		public decimal Confidence { get; set; }
+        /// <summary>
+        /// Calculated average confidence that the detection contains a whale sound.
+        /// </summary>
+        /// <example>84.39</example>
+        public decimal Confidence { get; set; }
 
-		/// <summary>
-		/// Identity of the human moderator (User Principal Name for AzureAD) performing the review.
-		/// </summary>
-		/// <example>user@gmail.com</example>
-		public string Moderator { get; set; }
+        /// <summary>
+        /// Identity of the human moderator (User Principal Name for AzureAD) performing the review.
+        /// </summary>
+        /// <example>user@gmail.com</example>
+        public string Moderator { get; set; }
 
-		/// <summary>
-		/// Date and time of when the detection was reviewed by the human moderator.
-		/// </summary>
-		/// <example>2020-09-30T11:03:56Z</example>
-		public DateTime Moderated { get; set; }
+        /// <summary>
+        /// Date and time of when the detection was reviewed by the human moderator.
+        /// </summary>
+        /// <example>2020-09-30T11:03:56Z</example>
+        public DateTime Moderated { get; set; }
 
-		/// <summary>
-		/// Any text comments entered by the human moderator during review (separated by semi-colon).
-		/// </summary>
-		/// <example>S7;S10</example>
-		public string Tags { get; set; }
+        /// <summary>
+        /// Any text comments entered by the human moderator during review (separated by semi-colon).
+        /// </summary>
+        /// <example>S7;S10</example>
+        public string Tags { get; set; }
 
-		/// <summary>
-		/// Split tags into a list.
-		/// </summary>
-		/// <param name="tags">Tags string to split</param>
-		/// <returns>List of tags</returns>
-		public static List<string> GetTagList(string tags)
-		{
-			if (string.IsNullOrWhiteSpace(tags))
-				return new List<string>();
+        /// <summary>
+        /// Split tags into a list.
+        /// </summary>
+        /// <param name="tags">Tags string to split</param>
+        /// <returns>List of tags</returns>
+        public static List<string> GetTagList(string tags)
+        {
+            if (string.IsNullOrWhiteSpace(tags))
+                return new List<string>();
 
-			string[] delimiters = new string[] { ";", "," };
-			var rawTags = tags.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
-			var tagList = new List<string>(rawTags.Length);
-			foreach (var rawTag in rawTags)
-			{
-				var trimmed = rawTag.Trim();
-				if (trimmed.Length > 0)
-					tagList.Add(trimmed);
-			}
-			return tagList;
-		}
+            string[] delimiters = new string[] { ";", "," };
+            var rawTags = tags.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            var tagList = new List<string>(rawTags.Length);
+            foreach (var rawTag in rawTags)
+            {
+                var trimmed = rawTag.Trim();
+                if (trimmed.Length > 0)
+                    tagList.Add(trimmed);
+            }
+            return tagList;
+        }
 
-		/// <summary>
-		/// Get the leaf tags from the given tags string.
-		/// A leaf tag is a tag that does not have any child tags in the input list.
-		/// </summary>
-		/// <param name="tags"></param>
-		/// <returns></returns>
-		public static List<string> GetLeafTags(string tags)
-		{
-			List<string> tagList = GetTagList(tags);
-			List<string> leafTags = new List<string>();
-			foreach (var tag in tagList)
-			{
-				bool isLeaf = true;
-				foreach (var pair in TagHierarchy)
-				{
-					if (tag.Equals(pair.Value, StringComparison.OrdinalIgnoreCase) && tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
-					{
-						isLeaf = false;
-						break;
-					}
-				}
-				if (isLeaf)
-				{
-					leafTags.Add(tag);
-				}
-			}
-			return leafTags;
-		}
+        /// <summary>
+        /// Get the leaf tags from the given tags string.
+        /// A leaf tag is a tag that does not have any child tags in the input list.
+        /// </summary>
+        /// <param name="tags"></param>
+        /// <returns></returns>
+        public static List<string> GetLeafTags(string tags)
+        {
+            List<string> tagList = GetTagList(tags);
+            List<string> leafTags = new List<string>();
+            foreach (var tag in tagList)
+            {
+                bool isLeaf = true;
+                foreach (var pair in TagHierarchy)
+                {
+                    if (tag.Equals(pair.Value, StringComparison.OrdinalIgnoreCase) && tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        isLeaf = false;
+                        break;
+                    }
+                }
+                if (isLeaf)
+                {
+                    leafTags.Add(tag);
+                }
+            }
+            return leafTags;
+        }
 
-		/// <summary>
-		/// Tags in a list (parsed from the Tags string).
-		/// </summary>
-		public List<string> TagList => GetTagList(Tags);
+        /// <summary>
+        /// Tags in a list (parsed from the Tags string).
+        /// </summary>
+        public List<string> TagList => GetTagList(Tags);
 
-		/// <summary>
-		/// Hierarchy of tags, where the key is the child tag and the value is the parent tag.
-		/// A null value indicates a top-level tag. Within tags at the same level, more likely
-		/// entries should typically appear before less likely entries.
-		/// </summary>
-		public static readonly Dictionary<string, string> TagHierarchy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-		{
-			{ "whale", null },
-			{ "orca", "whale" },
-			{ "srkw", "orca" },
-			{ "J pod", "srkw" },
-			{ "K pod", "srkw" },
-			{ "L pod", "srkw" },
-			{ "transient", "orca" },
-			{ "humpback", "whale" },
-			{ "vessel", null },
-			{ "train", "vessel" },
-			{ "bird", null },
-			{ "pigu", "bird" },
-			{ "keir", "bird" },
-			{ "human", null },
-			{ "jingle", null },
-			{ "water", null },
-			{ "hum", null },
-		};
+        /// <summary>
+        /// Hierarchy of tags, where the key is the child tag and the value is the parent tag.
+        /// A null value indicates a top-level tag. Within tags at the same level, more likely
+        /// entries should typically appear before less likely entries.
+        /// </summary>
+        public static readonly Dictionary<string, string> TagHierarchy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "whale", null },
+            { "orca", "whale" },
+            { "srkw", "orca" },
+            { "J pod", "srkw" },
+            { "K pod", "srkw" },
+            { "L pod", "srkw" },
+            { "transient", "orca" },
+            { "humpback", "whale" },
+            { "vessel", null },
+            { "train", "vessel" },
+            { "bird", null },
+            { "pigu", "bird" },
+            { "keir", "bird" },
+            { "human", null },
+            { "jingle", null },
+            { "water", null },
+            { "hum", null },
+        };
 
-		/// <summary>
-		/// List of suggested tags for the detection based on the machine prediction, the tag hierarchy,
-		/// and the most recently moderated detection. Tags that are already in the TagList are not
-		/// included in the suggestions.
-		/// </summary>
-		public List<string> SuggestedTagList
-		{
-			get
-			{
-				List<string> suggestions = new List<string>();
+        /// <summary>
+        /// List of suggested tags for the detection based on the machine prediction, the tag hierarchy,
+        /// and the most recently moderated detection. Tags that are already in the TagList are not
+        /// included in the suggestions.
+        /// </summary>
+        public List<string> SuggestedTagList
+        {
+            get
+            {
+                List<string> suggestions = new List<string>();
 
-				// For each tag in the tags list, add any child tags not already in the tags list.
-				var tagList = TagList;
-				foreach (var tag in tagList)
-				{
-					foreach (var pair in TagHierarchy)
-					{
-						if (tag.Equals(pair.Value, StringComparison.OrdinalIgnoreCase) && !tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
-						{
-							suggestions.Add(pair.Key);
-						}
-					}
-				}
+                // For each tag in the tags list, add any child tags not already in the tags list.
+                var tagList = TagList;
+                foreach (var tag in tagList)
+                {
+                    foreach (var pair in TagHierarchy)
+                    {
+                        if (tag.Equals(pair.Value, StringComparison.OrdinalIgnoreCase) && !tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
+                        {
+                            suggestions.Add(pair.Key);
+                        }
+                    }
+                }
 
-				// Add any top-level tags not already in the tags list.
-				foreach (var pair in TagHierarchy)
-				{
-					if (pair.Value == null && !tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
-					{
-						suggestions.Add(pair.Key);
-					}
-				}
+                // Add any top-level tags not already in the tags list.
+                foreach (var pair in TagHierarchy)
+                {
+                    if (pair.Value == null && !tagList.Contains(pair.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        suggestions.Add(pair.Key);
+                    }
+                }
 
-				return suggestions;
-			}
-		}
+                return suggestions;
+            }
+        }
 
-		/// <summary>
-		/// Machine-generated label for the detection based on the global prediction model.
-		/// </summary>
-		public string GlobalPredictionLabel { get; set; }
+        /// <summary>
+        /// Machine-generated label for the detection based on the global prediction model.
+        /// </summary>
+        public string GlobalPredictionLabel { get; set; }
 
-		/// <summary>
-		/// AI Model that reported this detection.
-		/// </summary>
-		public string AIModel => string.IsNullOrEmpty(GlobalPredictionLabel) ? "OrcaHello" : "PODS-AI";
-	}
+        /// <summary>
+        /// AI Model that reported this detection.
+        /// </summary>
+        public string AIModel => string.IsNullOrEmpty(GlobalPredictionLabel) ? "OrcaHello" : "PODS-AI";
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionQueryParameters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionQueryParameters.cs
@@ -2,73 +2,73 @@
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Query parameters to present to the detections endpoint.
-	/// </summary>
-	public class DetectionQueryParameters
-	{
-		/// <summary>
-		/// Page number to retrieve.
-		/// </summary>
-		/// <example>1</example>
-		public int Page { get; set; } = 1;
+    /// <summary>
+    /// Query parameters to present to the detections endpoint.
+    /// </summary>
+    public class DetectionQueryParameters
+    {
+        /// <summary>
+        /// Page number to retrieve.
+        /// </summary>
+        /// <example>1</example>
+        public int Page { get; set; } = 1;
 
-		/// <summary>
-		/// Property to sort by (confidence, timestamp).
-		/// </summary>
-		/// <example>timestamp</example>
-		public string SortBy { get; set; } = "timestamp";
+        /// <summary>
+        /// Property to sort by (confidence, timestamp).
+        /// </summary>
+        /// <example>timestamp</example>
+        public string SortBy { get; set; } = "timestamp";
 
-		/// <summary>
-		/// Order in which to sort the results (asc, desc).
-		/// </summary>
-		/// <example>desc</example>
-		public string SortOrder { get; set; } = "desc";
+        /// <summary>
+        /// Order in which to sort the results (asc, desc).
+        /// </summary>
+        /// <example>desc</example>
+        public string SortOrder { get; set; } = "desc";
 
-		/// <summary>
-		/// Timeframe for the record set (last 30m, 3h, 6h, 24h, 1w, 1m, range, all).
-		/// </summary>
-		/// <example>all</example>
-		public string Timeframe { get; set; } = "all";
+        /// <summary>
+        /// Timeframe for the record set (last 30m, 3h, 6h, 24h, 1w, 1m, range, all).
+        /// </summary>
+        /// <example>all</example>
+        public string Timeframe { get; set; } = "all";
 
-		/// <summary>
-		/// Date range filter for from Date (mm/dd/yyyy)
-		/// </summary>
-		/// <example>12/01/2021</example>
-		public DateTime? DateFrom { get; set; }
+        /// <summary>
+        /// Date range filter for from Date (mm/dd/yyyy)
+        /// </summary>
+        /// <example>12/01/2021</example>
+        public DateTime? DateFrom { get; set; }
 
-		/// <summary>
-		/// Date range filter for To Date (mm/dd/yyyy)
-		/// </summary>
-		/// <example>01/15/2022</example>
-		public DateTime? DateTo { get; set; }
+        /// <summary>
+        /// Date range filter for To Date (mm/dd/yyyy)
+        /// </summary>
+        /// <example>01/15/2022</example>
+        public DateTime? DateTo { get; set; }
 
-		/// <summary>
-		/// Location of the hydrophone (all, Orcasound Lab, Port Townsend, etc.).
-		/// </summary>
-		/// <example>all</example>
-		public string Location { get; set; } = "all";
+        /// <summary>
+        /// Location of the hydrophone (all, Orcasound Lab, Port Townsend, etc.).
+        /// </summary>
+        /// <example>all</example>
+        public string Location { get; set; } = "all";
 
-		/// <summary>
-		/// Hydrophone ID (rpi_orcasound_lab, etc., or all).
-		/// </summary>
-		/// <example>all</example>
-		public string HydrophoneId { get; set; } = "all";
+        /// <summary>
+        /// Hydrophone ID (rpi_orcasound_lab, etc., or all).
+        /// </summary>
+        /// <example>all</example>
+        public string HydrophoneId { get; set; } = "all";
 
-		/// <summary>
-		/// Number of records per page to retrieve.
-		/// </summary>
-		/// <example>5</example>
-		public int RecordsPerPage
-		{
-			get => _recordsPerPage;
-			set
-			{
-				_recordsPerPage = (value > _maxRecordsPerPage) ? _maxRecordsPerPage : value;
-			}
-		}
+        /// <summary>
+        /// Number of records per page to retrieve.
+        /// </summary>
+        /// <example>5</example>
+        public int RecordsPerPage
+        {
+            get => _recordsPerPage;
+            set
+            {
+                _recordsPerPage = (value > _maxRecordsPerPage) ? _maxRecordsPerPage : value;
+            }
+        }
 
-		private int _recordsPerPage = 10;
-		private readonly int _maxRecordsPerPage = 50;
-	}
+        private int _recordsPerPage = 10;
+        private readonly int _maxRecordsPerPage = 50;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionUpdate.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/DetectionUpdate.cs
@@ -2,51 +2,51 @@
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Detection data to be updated.
-	/// </summary>
-	public class DetectionUpdate
-	{
-		/// <summary>
-		/// The detection's unique ID.
-		/// </summary>
-		/// <example>AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA</example>
-		public string Id { get; set; }
+    /// <summary>
+    /// Detection data to be updated.
+    /// </summary>
+    public class DetectionUpdate
+    {
+        /// <summary>
+        /// The detection's unique ID.
+        /// </summary>
+        /// <example>AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA</example>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// Comments provided by the human moderator.
-		/// </summary>
-		/// <example>Didn't hear anything of interest.</example>
-		public string Comments { get; set; }
+        /// <summary>
+        /// Comments provided by the human moderator.
+        /// </summary>
+        /// <example>Didn't hear anything of interest.</example>
+        public string Comments { get; set; }
 
-		/// <summary>
-		/// Tags provided by the human moderator (separated by semi-colon)
-		/// </summary>
-		/// <example>call;snr-medium</example>
-		public string Tags { get; set; }
+        /// <summary>
+        /// Tags provided by the human moderator (separated by semi-colon)
+        /// </summary>
+        /// <example>call;snr-medium</example>
+        public string Tags { get; set; }
 
-		/// <summary>
-		/// Identity of the human moderator (User Principal Name for AzureAD) reviewing the detection.
-		/// </summary>
-		/// <example>live.com#user@gmail.com</example>
-		public string Moderator { get; set; }
+        /// <summary>
+        /// Identity of the human moderator (User Principal Name for AzureAD) reviewing the detection.
+        /// </summary>
+        /// <example>live.com#user@gmail.com</example>
+        public string Moderator { get; set; }
 
-		/// <summary>
-		/// Date and time when the detection was moderated.
-		/// </summary>
-		/// <example>2020-11-21T16:52:45Z</example>
-		public DateTime Moderated { get; set; }
+        /// <summary>
+        /// Date and time when the detection was moderated.
+        /// </summary>
+        /// <example>2020-11-21T16:52:45Z</example>
+        public DateTime Moderated { get; set; }
 
-		/// <summary>
-		/// Flag indicating whether or not the detection has been reviewed.
-		/// </summary>
-		/// <example>true</example>
-		public bool Reviewed { get; set; }
+        /// <summary>
+        /// Flag indicating whether or not the detection has been reviewed.
+        /// </summary>
+        /// <example>true</example>
+        public bool Reviewed { get; set; }
 
-		/// <summary>
-		/// Indicates whether whale sounds were heard in the detection (yes, no, don't know).
-		/// </summary>
-		/// <example>no</example>
-		public string Found { get; set; }
-	}
+        /// <summary>
+        /// Indicates whether whale sounds were heard in the detection (yes, no, don't know).
+        /// </summary>
+        /// <example>no</example>
+        public string Found { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Location.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Location.cs
@@ -1,26 +1,26 @@
 ﻿namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Geographical location of the hydrophone that collected the detection.
-	/// </summary>
-	public class Location
-	{
-		/// <summary>
-		/// Name of the hydrophone location.
-		/// </summary>
-		/// <example>Orcasound Lab</example>
-		public string Name { get; set; }
+    /// <summary>
+    /// Geographical location of the hydrophone that collected the detection.
+    /// </summary>
+    public class Location
+    {
+        /// <summary>
+        /// Name of the hydrophone location.
+        /// </summary>
+        /// <example>Orcasound Lab</example>
+        public string Name { get; set; }
 
-		/// <summary>
-		/// Longitude of the hydrophone's location.
-		/// </summary>
-		/// <example>-123.2166658</example>
-		public double Longitude { get; set; }
+        /// <summary>
+        /// Longitude of the hydrophone's location.
+        /// </summary>
+        /// <example>-123.2166658</example>
+        public double Longitude { get; set; }
 
-		/// <summary>
-		/// Latitude of the hydrophone's location.
-		/// </summary>
-		/// <example>48.5499978</example>
-		public double Latitude { get; set; }
-	}
+        /// <summary>
+        /// Latitude of the hydrophone's location.
+        /// </summary>
+        /// <example>48.5499978</example>
+        public double Latitude { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/Metrics.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/Metrics.cs
@@ -2,77 +2,77 @@
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Activity metrics for the entire system.
-	/// </summary>
-	public class Metrics
-	{
-		/// <summary>
-		/// Activity timeframe (30m, 24h, etc.).
-		/// </summary>
-		/// <example>30d</example>
-		public string Timeframe { get; set; }
+    /// <summary>
+    /// Activity metrics for the entire system.
+    /// </summary>
+    public class Metrics
+    {
+        /// <summary>
+        /// Activity timeframe (30m, 24h, etc.).
+        /// </summary>
+        /// <example>30d</example>
+        public string Timeframe { get; set; }
 
-		/// <summary>
-		/// Number of reviewed detections in timeframe.
-		/// </summary>
-		public int Reviewed { get; set; }
+        /// <summary>
+        /// Number of reviewed detections in timeframe.
+        /// </summary>
+        public int Reviewed { get; set; }
 
-		/// <summary>
-		/// Number of detections not reviewed in timeframe.
-		/// </summary>
-		/// <example>15</example>
-		public int Unreviewed { get; set; }
+        /// <summary>
+        /// Number of detections not reviewed in timeframe.
+        /// </summary>
+        /// <example>15</example>
+        public int Unreviewed { get; set; }
 
-		/// <summary>
-		/// Number of detections in timeframe confirmed by human moderator to have whale sound.
-		/// </summary>
-		/// <example>100</example>
-		public int ConfirmedDetection { get; set; }
+        /// <summary>
+        /// Number of detections in timeframe confirmed by human moderator to have whale sound.
+        /// </summary>
+        /// <example>100</example>
+        public int ConfirmedDetection { get; set; }
 
-		/// <summary>
-		/// Number of detections in timeframe confirmed by human moderator to not have whale sound.
-		/// </summary>
-		/// <example>5</example>
-		public int FalseDetection { get; set; }
+        /// <summary>
+        /// Number of detections in timeframe confirmed by human moderator to not have whale sound.
+        /// </summary>
+        /// <example>5</example>
+        public int FalseDetection { get; set; }
 
-		/// <summary>
-		/// Number of detections in timeframe where human moderator could not determine if there was whale sound.
-		/// </summary>
-		/// <example>1</example>
-		public int UnknownDetection { get; set; }
+        /// <summary>
+        /// Number of detections in timeframe where human moderator could not determine if there was whale sound.
+        /// </summary>
+        /// <example>1</example>
+        public int UnknownDetection { get; set; }
 
-		/// <summary>
-		/// List of all comments in timeframe concerning confirmed detections.
-		/// </summary>
-		public List<MetricsComment> ConfirmedComments { get; set; } = new List<MetricsComment>();
+        /// <summary>
+        /// List of all comments in timeframe concerning confirmed detections.
+        /// </summary>
+        public List<MetricsComment> ConfirmedComments { get; set; } = new List<MetricsComment>();
 
-		/// <summary>
-		/// List of all comments in timeframe concerning unconfirmed or unknown detections.
-		/// </summary>
-		public List<MetricsComment> UnconfirmedComments { get; set; } = new List<MetricsComment>();
+        /// <summary>
+        /// List of all comments in timeframe concerning unconfirmed or unknown detections.
+        /// </summary>
+        public List<MetricsComment> UnconfirmedComments { get; set; } = new List<MetricsComment>();
 
-		/// <summary>
-		/// List of all tags in timeframe.
-		/// </summary>
-		public List<MetricsTag> Tags { get; set; } = new List<MetricsTag>();
+        /// <summary>
+        /// List of all tags in timeframe.
+        /// </summary>
+        public List<MetricsTag> Tags { get; set; } = new List<MetricsTag>();
 
-		/// <summary>
-		/// Formatted detections reviewed/unreviewed for passing to JSInterop.
-		/// </summary>
-		/// <example>[5, 20]</example>
-		public string DetectionsArray => $"[{Reviewed}, {Unreviewed}]";
+        /// <summary>
+        /// Formatted detections reviewed/unreviewed for passing to JSInterop.
+        /// </summary>
+        /// <example>[5, 20]</example>
+        public string DetectionsArray => $"[{Reviewed}, {Unreviewed}]";
 
-		/// <summary>
-		/// Formatted detection results for passing to JSInterop.
-		/// </summary>
-		/// <example>[6, 3, 30]</example>
-		public string DetectionResultsArray => $"[{ConfirmedDetection}, {FalseDetection}, {UnknownDetection}]";
+        /// <summary>
+        /// Formatted detection results for passing to JSInterop.
+        /// </summary>
+        /// <example>[6, 3, 30]</example>
+        public string DetectionResultsArray => $"[{ConfirmedDetection}, {FalseDetection}, {UnknownDetection}]";
 
-		/// <summary>
-		/// Flag to be set if no metrics retrieved.
-		/// </summary>
-		/// <example>true</example>
-		public bool HasContent { get; set; } = false;
-	}
+        /// <summary>
+        /// Flag to be set if no metrics retrieved.
+        /// </summary>
+        /// <example>true</example>
+        public bool HasContent { get; set; } = false;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/MetricsComment.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/MetricsComment.cs
@@ -2,33 +2,33 @@
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Information about entered comment.
-	/// </summary>
-	public class MetricsComment
-	{
-		/// <summary>
-		/// The text of the comment.
-		/// </summary>
-		/// <example>This is the thing the Moderator said about the detection.</example>
-		public string Comment { get; set; }
+    /// <summary>
+    /// Information about entered comment.
+    /// </summary>
+    public class MetricsComment
+    {
+        /// <summary>
+        /// The text of the comment.
+        /// </summary>
+        /// <example>This is the thing the Moderator said about the detection.</example>
+        public string Comment { get; set; }
 
-		/// <summary>
-		/// The detection's unique Id.
-		/// </summary>
-		/// <example>00000000-0000-0000-0000-000000000000</example>
-		public string Id { get; set; }
+        /// <summary>
+        /// The detection's unique Id.
+        /// </summary>
+        /// <example>00000000-0000-0000-0000-000000000000</example>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// Date and time when the comment was submitted.
-		/// </summary>
-		/// <example>2020-11-19T13:42:32.473918Z</example>
-		public DateTime Timestamp { get; set; }
+        /// <summary>
+        /// Date and time when the comment was submitted.
+        /// </summary>
+        /// <example>2020-11-19T13:42:32.473918Z</example>
+        public DateTime Timestamp { get; set; }
 
-		/// <summary>
-		/// Identity of the human moderator (User Principal Name for AzureAD) submitting the comment.
-		/// </summary>
-		/// <example>live.com#user@gmail.com</example>
-		public string Moderator { get; set; }
-	}
+        /// <summary>
+        /// Identity of the human moderator (User Principal Name for AzureAD) submitting the comment.
+        /// </summary>
+        /// <example>live.com#user@gmail.com</example>
+        public string Moderator { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/MetricsTag.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/MetricsTag.cs
@@ -2,21 +2,21 @@
 
 namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Information about entered tag.
-	/// </summary>
-	public class MetricsTag
-	{
-		/// <summary>
-		/// Tag name.
-		/// </summary>
-		/// <exampl>CLANG</exampl>
-		public string Tag { get; set; }
+    /// <summary>
+    /// Information about entered tag.
+    /// </summary>
+    public class MetricsTag
+    {
+        /// <summary>
+        /// Tag name.
+        /// </summary>
+        /// <exampl>CLANG</exampl>
+        public string Tag { get; set; }
 
-		/// <summary>
-		/// List of detection unique Ids associated with this tag.
-		/// </summary>
-		/// <example>["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000"]</example>
-		public List<string> Ids { get; set; } = new List<string>();
-	}
+        /// <summary>
+        /// List of detection unique Ids associated with this tag.
+        /// </summary>
+        /// <example>["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000"]</example>
+        public List<string> Ids { get; set; } = new List<string>();
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/ModeratorMetrics.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Metrics/ModeratorMetrics.cs
@@ -1,13 +1,13 @@
 ﻿namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Activity metrics for the specified human moderator.
-	/// </summary>
-	public class ModeratorMetrics : Metrics
-	{
-		/// <summary>
-		/// Identity of the human moderator (User Principal Name for AzureAD) performing the review.
-		/// </summary>
-		public string Moderator { get; set; }
-	}
+    /// <summary>
+    /// Activity metrics for the specified human moderator.
+    /// </summary>
+    public class ModeratorMetrics : Metrics
+    {
+        /// <summary>
+        /// Identity of the human moderator (User Principal Name for AzureAD) performing the review.
+        /// </summary>
+        public string Moderator { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Tags/TagUpdate.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Tags/TagUpdate.cs
@@ -17,7 +17,7 @@ namespace AIForOrcas.DTO.API.Tags
         /// What the Tag is being change to
         /// </summary>
         /// <example>NewTag</example>
-        [Required(ErrorMessage="Please enter the new tag.")]
+        [Required(ErrorMessage = "Please enter the new tag.")]
         public string NewTag { get; set; }
     }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/CandidateFilterOptionsDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/CandidateFilterOptionsDTO.cs
@@ -2,15 +2,15 @@
 
 namespace AIForOrcas.DTO
 {
-	public class CandidateFilterOptionsDTO : IFilterOptions
-	{
-		public string SortOrder { get; set; }
-		public string SortBy { get; set; }
-		public string Timeframe { get; set; }
-		public string Location { get; set; }
-		public string HydrophoneId { get; set; }
-		public DateTime? DateFrom { get; set; }
-		public DateTime? DateTo { get; set; }
-		public string QueryString { get => $"sortBy={SortBy}&sortOrder={SortOrder}&timeframe={Timeframe}&location={Location}&hydrophoneId={HydrophoneId}&dateFrom={DateFrom}&dateTo={DateTo}"; }
-	}
+    public class CandidateFilterOptionsDTO : IFilterOptions
+    {
+        public string SortOrder { get; set; }
+        public string SortBy { get; set; }
+        public string Timeframe { get; set; }
+        public string Location { get; set; }
+        public string HydrophoneId { get; set; }
+        public DateTime? DateFrom { get; set; }
+        public DateTime? DateTo { get; set; }
+        public string QueryString { get => $"sortBy={SortBy}&sortOrder={SortOrder}&timeframe={Timeframe}&location={Location}&hydrophoneId={HydrophoneId}&dateFrom={DateFrom}&dateTo={DateTo}"; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/IFilterOptions.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/IFilterOptions.cs
@@ -1,7 +1,7 @@
 ﻿namespace AIForOrcas.DTO
 {
-	public interface IFilterOptions
-	{
-		string QueryString { get; }
-	}
+    public interface IFilterOptions
+    {
+        string QueryString { get; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/MetricsFilterDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/MetricsFilterDTO.cs
@@ -3,20 +3,20 @@ using System.Text.Json.Serialization;
 
 namespace AIForOrcas.DTO
 {
-	/// <summary>
-	/// Query parameters for metrics endpoint.
-	/// </summary>
-	[DataContract]
-	public class MetricsFilterDTO : IFilterOptions
-	{
-		/// <summary>
-		/// Timeframe for the record set (last 30m, 3h, 6h, 24h, 1w, 1m, all).
-		/// </summary>
-		/// <example>all</example>
-		[DataMember]
-		public string Timeframe { get; set; }
+    /// <summary>
+    /// Query parameters for metrics endpoint.
+    /// </summary>
+    [DataContract]
+    public class MetricsFilterDTO : IFilterOptions
+    {
+        /// <summary>
+        /// Timeframe for the record set (last 30m, 3h, 6h, 24h, 1w, 1m, all).
+        /// </summary>
+        /// <example>all</example>
+        [DataMember]
+        public string Timeframe { get; set; }
 
-		[JsonIgnore]
-		public virtual string QueryString => $"timeframe={Timeframe}";
-	}
+        [JsonIgnore]
+        public virtual string QueryString => $"timeframe={Timeframe}";
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/ModeratorMetricsFilterDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/ModeratorMetricsFilterDTO.cs
@@ -1,18 +1,18 @@
 ﻿namespace AIForOrcas.DTO.API
 {
-	/// <summary>
-	/// Query parameters for user metrics endpoint.
-	/// </summary>
-	public class ModeratorMetricsFilterDTO : MetricsFilterDTO
-	{
-		/// <summary>
-		/// Identity of the human moderator (User Principal Name for AzureAD) reviewing metrics.
-		/// </summary>
-		public string Moderator { get; set; }
+    /// <summary>
+    /// Query parameters for user metrics endpoint.
+    /// </summary>
+    public class ModeratorMetricsFilterDTO : MetricsFilterDTO
+    {
+        /// <summary>
+        /// Identity of the human moderator (User Principal Name for AzureAD) reviewing metrics.
+        /// </summary>
+        public string Moderator { get; set; }
 
-		/// <summary>
-		/// Constructed queryString.
-		/// </summary>
-		public override string QueryString => $"moderator={Moderator}&{base.QueryString}";
-	}
+        /// <summary>
+        /// Constructed queryString.
+        /// </summary>
+        public override string QueryString => $"moderator={Moderator}&{base.QueryString}";
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PageLinkDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PageLinkDTO.cs
@@ -1,24 +1,24 @@
 ﻿namespace AIForOrcas.DTO
 {
-	public class PageLinkDTO
-	{
-		public PageLinkDTO(int page)
-	: this(page, true) { }
+    public class PageLinkDTO
+    {
+        public PageLinkDTO(int page)
+    : this(page, true) { }
 
-		public PageLinkDTO(int page, bool enabled)
-			: this(page, enabled, page.ToString())
-		{ }
+        public PageLinkDTO(int page, bool enabled)
+            : this(page, enabled, page.ToString())
+        { }
 
-		public PageLinkDTO(int page, bool enabled, string text)
-		{
-			Page = page;
-			Enabled = enabled;
-			Text = text;
-		}
+        public PageLinkDTO(int page, bool enabled, string text)
+        {
+            Page = page;
+            Enabled = enabled;
+            Text = text;
+        }
 
-		public string Text { get; set; }
-		public int Page { get; set; }
-		public bool Enabled { get; set; } = true;
-		public bool Active { get; set; } = false;
-	}
+        public string Text { get; set; }
+        public int Page { get; set; }
+        public bool Enabled { get; set; } = true;
+        public bool Active { get; set; } = false;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginatedResponseDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginatedResponseDTO.cs
@@ -1,9 +1,9 @@
 ﻿namespace AIForOrcas.DTO
 {
-	public class PaginatedResponseDTO<T>
-	{
-		public T Response { get; set; }
-		public int TotalAmountPages { get; set; }
-		public int TotalNumberRecords { get; set; }
-	}
+    public class PaginatedResponseDTO<T>
+    {
+        public T Response { get; set; }
+        public int TotalAmountPages { get; set; }
+        public int TotalNumberRecords { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginationOptionsDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginationOptionsDTO.cs
@@ -1,13 +1,13 @@
 ﻿namespace AIForOrcas.DTO
 {
-	public class PaginationOptionsDTO
-	{
-		public int Page { get; set; } = 1;
+    public class PaginationOptionsDTO
+    {
+        public int Page { get; set; } = 1;
 
-		public int RecordsPerPage { get; set; } = 10;
+        public int RecordsPerPage { get; set; } = 10;
 
-		public int Radius { get; set; } = 3;
+        public int Radius { get; set; } = 3;
 
-		public string QueryString { get => $"page={Page}&recordsPerPage={RecordsPerPage}";  }
-	}
+        public string QueryString { get => $"page={Page}&recordsPerPage={RecordsPerPage}"; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginationResultsDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/PaginationResultsDTO.cs
@@ -1,9 +1,9 @@
 ﻿namespace AIForOrcas.DTO
 {
-	public class PaginationResultsDTO
-	{
-		public int CurrentPage { get; set; } = 1;
-		public int TotalNumberOfPages { get; set; } = 0;
-		public int TotalNumberOfRecords { get; set; } = 0;
-	}
+    public class PaginationResultsDTO
+    {
+        public int CurrentPage { get; set; } = 1;
+        public int TotalNumberOfPages { get; set; } = 0;
+        public int TotalNumberOfRecords { get; set; } = 0;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/ReviewedFilterOptionsDTO.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/Pagination/ReviewedFilterOptionsDTO.cs
@@ -2,14 +2,14 @@
 
 namespace AIForOrcas.DTO
 {
-	public class ReviewedFilterOptionsDTO : IFilterOptions
-	{
-		public string SortOrder { get; set; }
-		public string SortBy { get; set; }
-		public string Timeframe { get; set; }
-		public string Location { get; set; }
-		public DateTime? DateFrom { get; set; }
-		public DateTime? DateTo { get; set; }
-		public string QueryString { get => $"sortBy={SortBy}&sortOrder={SortOrder}&timeframe={Timeframe}&location={Location}&DateFrom={DateFrom}&DateTo={DateTo}"; }
-	}
+    public class ReviewedFilterOptionsDTO : IFilterOptions
+    {
+        public string SortOrder { get; set; }
+        public string SortBy { get; set; }
+        public string Timeframe { get; set; }
+        public string Location { get; set; }
+        public DateTime? DateFrom { get; set; }
+        public DateTime? DateTo { get; set; }
+        public string QueryString { get => $"sortBy={SortBy}&sortOrder={SortOrder}&timeframe={Timeframe}&location={Location}&DateFrom={DateFrom}&DateTo={DateTo}"; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Context/ApplicationDbContext.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Context/ApplicationDbContext.cs
@@ -3,22 +3,22 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AIForOrcas.Server.BL.Context
 {
-	public class ApplicationDbContext : DbContext
-	{
-		public DbSet<Metadata> Metadata { get; set; }
+    public class ApplicationDbContext : DbContext
+    {
+        public DbSet<Metadata> Metadata { get; set; }
 
-		public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-			: base(options)
-		{ }
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        { }
 
-		protected override void OnModelCreating(ModelBuilder modelBuilder)
-		{
-			modelBuilder.Entity<Metadata>().ToContainer("metadata");
-			modelBuilder.Entity<Metadata>().HasPartitionKey(o => o.source_guid);
-			modelBuilder.Entity<Metadata>().OwnsOne(p => p.location);
-			modelBuilder.Entity<Metadata>().OwnsMany(p => p.predictions);
-			modelBuilder.Entity<Metadata>().HasNoDiscriminator();
-			base.OnModelCreating(modelBuilder);
-		}
-	}
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Metadata>().ToContainer("metadata");
+            modelBuilder.Entity<Metadata>().HasPartitionKey(o => o.source_guid);
+            modelBuilder.Entity<Metadata>().OwnsOne(p => p.location);
+            modelBuilder.Entity<Metadata>().OwnsMany(p => p.predictions);
+            modelBuilder.Entity<Metadata>().HasNoDiscriminator();
+            base.OnModelCreating(modelBuilder);
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Location.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Location.cs
@@ -1,10 +1,10 @@
 ﻿namespace AIForOrcas.Server.BL.Models.CosmosDB
 {
-	public class Location
-	{
-		public string id { get; set; }
-		public string name { get; set; }
-		public double longitude { get; set; }
-		public double latitude { get; set; }
-	}
+    public class Location
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+        public double longitude { get; set; }
+        public double latitude { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Metadata.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Metadata.cs
@@ -3,22 +3,22 @@ using System.Collections.Generic;
 
 namespace AIForOrcas.Server.BL.Models.CosmosDB
 {
-	public class Metadata
-	{
-		public string id { get; set; }
-		public string source_guid { get; set; }
-		public string audioUri { get; set; }
-		public string imageUri { get; set; }
-		public bool reviewed { get; set; }
-		public DateTime timestamp { get; set; }
-		public decimal whaleFoundConfidence { get; set; }
-		public Location location { get; set; }
-		public List<Prediction> predictions { get; set; } = new List<Prediction>();
-		public string SRKWFound { get; set; }
-		public string comments { get; set; }
-		public string dateModerated { get; set; }
-		public string moderator { get; set; }
-		public string tags { get; set; }
-		public string globalPredictionLabel { get; set; }
-	}
+    public class Metadata
+    {
+        public string id { get; set; }
+        public string source_guid { get; set; }
+        public string audioUri { get; set; }
+        public string imageUri { get; set; }
+        public bool reviewed { get; set; }
+        public DateTime timestamp { get; set; }
+        public decimal whaleFoundConfidence { get; set; }
+        public Location location { get; set; }
+        public List<Prediction> predictions { get; set; } = new List<Prediction>();
+        public string SRKWFound { get; set; }
+        public string comments { get; set; }
+        public string dateModerated { get; set; }
+        public string moderator { get; set; }
+        public string tags { get; set; }
+        public string globalPredictionLabel { get; set; }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Prediction.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Models/CosmosDB/Prediction.cs
@@ -1,11 +1,11 @@
 ﻿namespace AIForOrcas.Server.BL.Models.CosmosDB
 {
-	public class Prediction
-	{
-		public int id { get; set; }
-		public decimal startTime { get; set; }
-		public decimal duration { get; set; }
-		public decimal confidence { get; set; }
-		public string label { get; set; } = string.Empty;
-	}
+    public class Prediction
+    {
+        public int id { get; set; }
+        public decimal startTime { get; set; }
+        public decimal duration { get; set; }
+        public decimal confidence { get; set; }
+        public string label { get; set; } = string.Empty;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Services/MetadataRepository.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server.BL/Services/MetadataRepository.cs
@@ -9,51 +9,51 @@ using System.Threading.Tasks;
 
 namespace AIForOrcas.Server.BL.Services
 {
-	public class MetadataRepository
-	{
-		private readonly ApplicationDbContext _db;
+    public class MetadataRepository
+    {
+        private readonly ApplicationDbContext _db;
 
-		public MetadataRepository(ApplicationDbContext db)
-		{
-			_db = db;
-		}
-
-		public IQueryable<Metadata> GetAll()
+        public MetadataRepository(ApplicationDbContext db)
         {
-			return _db.Metadata.AsQueryable();
+            _db = db;
         }
 
-		public async Task<Metadata> GetByIdAsync(string id)
-		{
-			return await _db.Metadata.FirstOrDefaultAsync(x => x.id == id);
-		}
-
-		public async Task CommitAsync()
-		{
-			try
-			{
-				await _db.SaveChangesAsync();
-			}
-			catch (Exception ex)
-			{
-				throw new DataException(ex.Message);
-			}
-		}
-
-		public IQueryable<string> GetAllTags()
-		{
-			return _db.Metadata
-				.Where(x => x.tags != null && x.tags != "")
-				.Select(x => x.tags)
-				.Distinct();
-		}
-
-		public IQueryable<Metadata> GetAllWithTag(string tag)
+        public IQueryable<Metadata> GetAll()
         {
-			return _db.Metadata.AsEnumerable()
-				.Where(x => x.tags != null && x.tags.Contains(tag))
-				.AsQueryable();
+            return _db.Metadata.AsQueryable();
+        }
+
+        public async Task<Metadata> GetByIdAsync(string id)
+        {
+            return await _db.Metadata.FirstOrDefaultAsync(x => x.id == id);
+        }
+
+        public async Task CommitAsync()
+        {
+            try
+            {
+                await _db.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new DataException(ex.Message);
+            }
+        }
+
+        public IQueryable<string> GetAllTags()
+        {
+            return _db.Metadata
+                .Where(x => x.tags != null && x.tags != "")
+                .Select(x => x.tags)
+                .Distinct();
+        }
+
+        public IQueryable<Metadata> GetAllWithTag(string tag)
+        {
+            return _db.Metadata.AsEnumerable()
+                .Where(x => x.tags != null && x.tags.Contains(tag))
+                .AsQueryable();
 
         }
-	}
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/DetectionsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/DetectionsController.cs
@@ -8,521 +8,521 @@
 [ApiController]
 public class DetectionsController : ControllerBase
 {
-	private readonly MetadataRepository _repository;
+    private readonly MetadataRepository _repository;
 
-	public DetectionsController(MetadataRepository repository)
-	{
-		_repository = repository;
-	}
+    public DetectionsController(MetadataRepository repository)
+    {
+        _repository = repository;
+    }
 
-	#region Helpers
+    #region Helpers
 
-	private void SetHeaderCounts(double totalRecords, int recordsPerPage)
-	{
-		double totalAmountPages = Math.Ceiling(totalRecords / recordsPerPage);
+    private void SetHeaderCounts(double totalRecords, int recordsPerPage)
+    {
+        double totalAmountPages = Math.Ceiling(totalRecords / recordsPerPage);
 
-		HttpContext.Response.Headers.Add("totalNumberRecords", totalRecords.ToString());
-		HttpContext.Response.Headers.Add("totalAmountPages", totalAmountPages.ToString());
-	}
+        HttpContext.Response.Headers.Add("totalNumberRecords", totalRecords.ToString());
+        HttpContext.Response.Headers.Add("totalAmountPages", totalAmountPages.ToString());
+    }
 
-	private static void ValidateQueryParameters(DetectionQueryParameters queryParameters)
-	{
-		if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
-			throw new ArgumentNullException("Timeframe");
+    private static void ValidateQueryParameters(DetectionQueryParameters queryParameters)
+    {
+        if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+            throw new ArgumentNullException("Timeframe");
 
-		if (queryParameters.DateFrom > queryParameters.DateTo)
-			throw new Exception("From Date should be less than To date");
+        if (queryParameters.DateFrom > queryParameters.DateTo)
+            throw new Exception("From Date should be less than To date");
 
-		if (string.IsNullOrWhiteSpace(queryParameters.SortBy))
-			throw new ArgumentNullException("SortBy");
+        if (string.IsNullOrWhiteSpace(queryParameters.SortBy))
+            throw new ArgumentNullException("SortBy");
 
-		if (string.IsNullOrWhiteSpace(queryParameters.SortOrder))
-			throw new ArgumentNullException("SortOrder");
+        if (string.IsNullOrWhiteSpace(queryParameters.SortOrder))
+            throw new ArgumentNullException("SortOrder");
 
-		if (string.IsNullOrWhiteSpace(queryParameters.Location))
-			throw new ArgumentNullException("Location");
+        if (string.IsNullOrWhiteSpace(queryParameters.Location))
+            throw new ArgumentNullException("Location");
 
-		if (queryParameters.Page == 0)
-			throw new ArgumentNullException("Page");
+        if (queryParameters.Page == 0)
+            throw new ArgumentNullException("Page");
 
-		if (queryParameters.RecordsPerPage == 0)
-			throw new ArgumentNullException("RecordsPerPage");
-	}
+        if (queryParameters.RecordsPerPage == 0)
+            throw new ArgumentNullException("RecordsPerPage");
+    }
 
-	private static void ApplyOptionalLocationAndHydrophoneFilters(ref IQueryable<Metadata> queryable, DetectionQueryParameters queryParameters)
-	{
-		if (queryParameters.Location.ToLower() != "all")
-			MetadataFilters.ApplyLocationFilter(ref queryable, queryParameters.Location);
+    private static void ApplyOptionalLocationAndHydrophoneFilters(ref IQueryable<Metadata> queryable, DetectionQueryParameters queryParameters)
+    {
+        if (queryParameters.Location.ToLower() != "all")
+            MetadataFilters.ApplyLocationFilter(ref queryable, queryParameters.Location);
 
-		if (queryParameters.HydrophoneId.ToLower() != "all")
-			MetadataFilters.ApplyHydrophoneIdFilter(ref queryable, queryParameters.HydrophoneId);
-	}
+        if (queryParameters.HydrophoneId.ToLower() != "all")
+            MetadataFilters.ApplyHydrophoneIdFilter(ref queryable, queryParameters.HydrophoneId);
+    }
 
-	private void ApplySortPaginationAndHeaders(ref List<Detection> results, double recordCount, DetectionQueryParameters queryParameters)
-	{
-		if (queryParameters.SortBy.ToLower() == "confidence")
-			DetectionFilters.ApplyConfidenceSortFilter(ref results, queryParameters.SortOrder);
-		else if (queryParameters.SortBy.ToLower() == "timestamp")
-			DetectionFilters.ApplyTimestampSortFilter(ref results, queryParameters.SortOrder);
+    private void ApplySortPaginationAndHeaders(ref List<Detection> results, double recordCount, DetectionQueryParameters queryParameters)
+    {
+        if (queryParameters.SortBy.ToLower() == "confidence")
+            DetectionFilters.ApplyConfidenceSortFilter(ref results, queryParameters.SortOrder);
+        else if (queryParameters.SortBy.ToLower() == "timestamp")
+            DetectionFilters.ApplyTimestampSortFilter(ref results, queryParameters.SortOrder);
 
-		DetectionFilters.ApplyPaginationFilter(ref results, queryParameters.Page, queryParameters.RecordsPerPage);
+        DetectionFilters.ApplyPaginationFilter(ref results, queryParameters.Page, queryParameters.RecordsPerPage);
 
-		SetHeaderCounts(recordCount,
-			(queryParameters.RecordsPerPage > 0 ? queryParameters.RecordsPerPage :
-				MetadataFilters.DefaultRecordsPerPage));
-	}
+        SetHeaderCounts(recordCount,
+            (queryParameters.RecordsPerPage > 0 ? queryParameters.RecordsPerPage :
+                MetadataFilters.DefaultRecordsPerPage));
+    }
 
-	#endregion
+    #endregion
 
-	/// <summary>
-	/// List all AI/ML generated detections, regardless of review status.
-	/// </summary>
-	[HttpGet]
+    /// <summary>
+    /// List all AI/ML generated detections, regardless of review status.
+    /// </summary>
+    [HttpGet]
     [AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the list of all Detections.", typeof(IQueryable<Detection>))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no Detections for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<IQueryable<Detection>> Get([FromQuery] DetectionQueryParameters queryParameters)
-	{
-		try
-		{
-			ValidateQueryParameters(queryParameters);
-
-			// start with all records
-			var queryable = _repository.GetAll();
-
-			// apply timeframe filter
-			MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
-
-			// apply location and hydrophone filters
-			ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
-
-			// If no detections found
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
-
-			// total number of records
-			double recordCount = queryable.Count();
-
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
-
-			// apply sort, pagination filters and set page count headers
-			ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
-
-			// map to returnable data type and return
-			return Ok(results);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// Fetch a specific detection based on a unique ID.
-	/// </summary>
-	/// <param name="id">Detection's unique ID</param>
-	[HttpGet("{id}")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the Detection.", typeof(Detection))]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status404NotFound, "If the Detection defined by the unique ID could not be found.")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public async ValueTask<ActionResult<Detection>> GetByIdAsync(string id)
-	{
-		try
-		{
-			if (string.IsNullOrWhiteSpace(id))
-				throw new ArgumentNullException("id");
-
-			var metadata = await _repository.GetByIdAsync(id);
-
-			if (metadata == null)
-				return NotFound();
-
-			return Ok(DetectionProcessors.ToDetection(metadata));
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// List all AI/ML generated detections that have not yet been reviewed (confirmed or rejected) by a human moderator.
-	/// </summary>
-	[HttpGet("unreviewed")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the list of unreviewed Detections.", typeof(IQueryable<Detection>))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no unreviewed Detections for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<IQueryable<Detection>> GetUnreviewed([FromQuery] DetectionQueryParameters queryParameters)
-	{
-		try
-		{
-			ValidateQueryParameters(queryParameters);
-
-			// start with all records
-			var queryable = _repository.GetAll();
-
-			// apply reviewed status
-			MetadataFilters.ApplyReviewedFilter(ref queryable, false);
-
-			// apply location and hydrophone filters
-			ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
-
-			// apply timeframe filter
-			MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
-
-			// If no detections found
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
-
-			// total number of records
-			double recordCount = queryable.Count();
-
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
-
-			// NOTE: Have to apply SortBy timestamp and pagination filter after
-			//       executing the select because of how EF for Cosmos deals with DateTime.
-			//       Had to convert from string (how stored in Cosmos) to DateTime in order to apply the
-			//       select, but that messed up the SortBy since Cosmos is expecting a string.
-
-			// apply sort, pagination filters and set page count headers
-			ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
-
-			// map to returnable data type and return
-			return Ok(results);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// List all AI/ML generated detections that have been reviewed by a human moderator and have confirmed whale sounds.
-	/// </summary>
-	[HttpGet("confirmed")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the list of confirmed Detections.", typeof(IQueryable<Detection>))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no confirmed Detections for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<IQueryable<Detection>> GetConfirmed([FromQuery] DetectionQueryParameters queryParameters)
-	{
-		try
-		{
-			ValidateQueryParameters(queryParameters);
-
-			// start with all records
-			var queryable = _repository.GetAll();
-
-			// apply desired status
-			MetadataFilters.ApplyReviewedFilter(ref queryable, true);
-
-			// apply desired found state
-			MetadataFilters.ApplyFoundFilter(ref queryable, "yes");
-
-			// apply timeframe filter
-			MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
-
-			// apply location and hydrophone filters
-			ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
-
-			// If no detections found
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
-
-			// total number of records
-			double recordCount = queryable.Count();
-
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
-
-			// apply sort, pagination filters and set page count headers
-			ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
-
-			// map to returnable data type and return
-			return Ok(results);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// List all AI/ML generated detections that have been reviewed by a human moderator, but do not have whale sounds.
-	/// </summary>
-	[HttpGet("falsepositives")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the list of false positive (unconfirmed) Detections.", typeof(IQueryable<Detection>))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no false positive Detections for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<IQueryable<Detection>> GetFalsePositives([FromQuery] DetectionQueryParameters queryParameters)
-	{
-		try
-		{
-			ValidateQueryParameters(queryParameters);
-
-			// start with all records
-			var queryable = _repository.GetAll();
-
-			// apply desired status
-			MetadataFilters.ApplyReviewedFilter(ref queryable, true);
-
-			// apply desired found state
-			MetadataFilters.ApplyFoundFilter(ref queryable, "no");
-
-			// apply timeframe filter
-			MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
-
-			// apply location and hydrophone filters
-			ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
-
-			// If no detections found
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
-
-			// total number of records
-			double recordCount = queryable.Count();
-
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
-
-			// apply sort, pagination filters and set page count headers
-			ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
-
-			// map to returnable data type and return
-			return Ok(results);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// List all AI/ML generated detections that have been reviewed by a human moderator, but whale sounds could not be conclusively confirmed or denied.
-	/// </summary>
-	[HttpGet("unknowns")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the list of unknown Detections.", typeof(IQueryable<Detection>))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no unknown Detections for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<IQueryable<Detection>> GetUnknowns([FromQuery] DetectionQueryParameters queryParameters)
-	{
-		try
-		{
-			ValidateQueryParameters(queryParameters);
-
-			// start with all records
-			var queryable = _repository.GetAll();
-
-			// apply desired status
-			MetadataFilters.ApplyReviewedFilter(ref queryable, true);
-
-			// apply desired found state
-			MetadataFilters.ApplyFoundFilter(ref queryable, "don't know");
-
-			// apply timeframe filter
-			MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
-
-			// apply location and hydrophone filters
-			ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
-
-			// If no detections found
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
-
-			// total number of records
-			double recordCount = queryable.Count();
-
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
-
-			// apply sort, pagination filters and set page count headers
-			ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
-
-			// map to returnable data type and return
-			return Ok(results);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
-
-	/// <summary>
-	/// Updates the detection with information provided by a human moderator.
-	/// </summary>
-	/// <param name="id">Detection's unique Id (AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA).</param>
-	/// <param name="detectionUpdate">The Detection's values to be updated.</param>
-	[HttpPut("{id}")]
-	[Authorize("Moderators")]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the contents of the updated Detection.", typeof(Detection))]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status401Unauthorized, "If the user is not logged in.")]
-	[SwaggerResponse(StatusCodes.Status403Forbidden, "If the user is logged in, but is not an authorized Moderator.")]
-	[SwaggerResponse(StatusCodes.Status404NotFound, "Indicates the Detection was not found to update.")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public async ValueTask<ActionResult<Detection>> Put(string id, [FromBody] DetectionUpdate detectionUpdate)
-	{
-		try
-		{
-			if (string.IsNullOrWhiteSpace(id))
-				throw new ArgumentNullException("id");
-
-			if (detectionUpdate == null)
-				throw new ArgumentNullException("postedDetection");
-
-			var metadata = await _repository.GetByIdAsync(id);
-
-			if (metadata == null)
-				return NotFound();
-
-			metadata.comments = detectionUpdate.Comments;
-			metadata.moderator = detectionUpdate.Moderator;
-			metadata.dateModerated = detectionUpdate.Moderated.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
-			metadata.reviewed = detectionUpdate.Reviewed;
-			metadata.SRKWFound = (string.IsNullOrWhiteSpace(detectionUpdate.Found)) ? "no" : detectionUpdate.Found.ToLower();
-
-			// Normalize the tags
-			if (!string.IsNullOrWhiteSpace(detectionUpdate.Tags))
-			{
-				var working = detectionUpdate.Tags.Replace(",", ";");
-
-				var tagList = new List<string>();
-				tagList.AddRange(working.Split(';').ToList().Select(x => x.Trim()));
-				metadata.tags = string.Join(";", tagList);
-			}
-			else
-			{
-				metadata.tags = string.Empty;
-			}
-
-			await _repository.CommitAsync();
-
-			return Ok(DetectionProcessors.ToDetection(metadata));
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
-
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the list of all Detections.", typeof(IQueryable<Detection>))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no Detections for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<IQueryable<Detection>> Get([FromQuery] DetectionQueryParameters queryParameters)
+    {
+        try
+        {
+            ValidateQueryParameters(queryParameters);
+
+            // start with all records
+            var queryable = _repository.GetAll();
+
+            // apply timeframe filter
+            MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
+
+            // apply location and hydrophone filters
+            ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
+
+            // If no detections found
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
+
+            // total number of records
+            double recordCount = queryable.Count();
+
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
+
+            // apply sort, pagination filters and set page count headers
+            ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
+
+            // map to returnable data type and return
+            return Ok(results);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// Fetch a specific detection based on a unique ID.
+    /// </summary>
+    /// <param name="id">Detection's unique ID</param>
+    [HttpGet("{id}")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the Detection.", typeof(Detection))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "If the Detection defined by the unique ID could not be found.")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public async ValueTask<ActionResult<Detection>> GetByIdAsync(string id)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentNullException("id");
+
+            var metadata = await _repository.GetByIdAsync(id);
+
+            if (metadata == null)
+                return NotFound();
+
+            return Ok(DetectionProcessors.ToDetection(metadata));
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// List all AI/ML generated detections that have not yet been reviewed (confirmed or rejected) by a human moderator.
+    /// </summary>
+    [HttpGet("unreviewed")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the list of unreviewed Detections.", typeof(IQueryable<Detection>))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no unreviewed Detections for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<IQueryable<Detection>> GetUnreviewed([FromQuery] DetectionQueryParameters queryParameters)
+    {
+        try
+        {
+            ValidateQueryParameters(queryParameters);
+
+            // start with all records
+            var queryable = _repository.GetAll();
+
+            // apply reviewed status
+            MetadataFilters.ApplyReviewedFilter(ref queryable, false);
+
+            // apply location and hydrophone filters
+            ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
+
+            // apply timeframe filter
+            MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
+
+            // If no detections found
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
+
+            // total number of records
+            double recordCount = queryable.Count();
+
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
+
+            // NOTE: Have to apply SortBy timestamp and pagination filter after
+            //       executing the select because of how EF for Cosmos deals with DateTime.
+            //       Had to convert from string (how stored in Cosmos) to DateTime in order to apply the
+            //       select, but that messed up the SortBy since Cosmos is expecting a string.
+
+            // apply sort, pagination filters and set page count headers
+            ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
+
+            // map to returnable data type and return
+            return Ok(results);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// List all AI/ML generated detections that have been reviewed by a human moderator and have confirmed whale sounds.
+    /// </summary>
+    [HttpGet("confirmed")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the list of confirmed Detections.", typeof(IQueryable<Detection>))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no confirmed Detections for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<IQueryable<Detection>> GetConfirmed([FromQuery] DetectionQueryParameters queryParameters)
+    {
+        try
+        {
+            ValidateQueryParameters(queryParameters);
+
+            // start with all records
+            var queryable = _repository.GetAll();
+
+            // apply desired status
+            MetadataFilters.ApplyReviewedFilter(ref queryable, true);
+
+            // apply desired found state
+            MetadataFilters.ApplyFoundFilter(ref queryable, "yes");
+
+            // apply timeframe filter
+            MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
+
+            // apply location and hydrophone filters
+            ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
+
+            // If no detections found
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
+
+            // total number of records
+            double recordCount = queryable.Count();
+
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
+
+            // apply sort, pagination filters and set page count headers
+            ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
+
+            // map to returnable data type and return
+            return Ok(results);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// List all AI/ML generated detections that have been reviewed by a human moderator, but do not have whale sounds.
+    /// </summary>
+    [HttpGet("falsepositives")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the list of false positive (unconfirmed) Detections.", typeof(IQueryable<Detection>))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no false positive Detections for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<IQueryable<Detection>> GetFalsePositives([FromQuery] DetectionQueryParameters queryParameters)
+    {
+        try
+        {
+            ValidateQueryParameters(queryParameters);
+
+            // start with all records
+            var queryable = _repository.GetAll();
+
+            // apply desired status
+            MetadataFilters.ApplyReviewedFilter(ref queryable, true);
+
+            // apply desired found state
+            MetadataFilters.ApplyFoundFilter(ref queryable, "no");
+
+            // apply timeframe filter
+            MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
+
+            // apply location and hydrophone filters
+            ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
+
+            // If no detections found
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
+
+            // total number of records
+            double recordCount = queryable.Count();
+
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
+
+            // apply sort, pagination filters and set page count headers
+            ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
+
+            // map to returnable data type and return
+            return Ok(results);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// List all AI/ML generated detections that have been reviewed by a human moderator, but whale sounds could not be conclusively confirmed or denied.
+    /// </summary>
+    [HttpGet("unknowns")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the list of unknown Detections.", typeof(IQueryable<Detection>))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no unknown Detections for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<IQueryable<Detection>> GetUnknowns([FromQuery] DetectionQueryParameters queryParameters)
+    {
+        try
+        {
+            ValidateQueryParameters(queryParameters);
+
+            // start with all records
+            var queryable = _repository.GetAll();
+
+            // apply desired status
+            MetadataFilters.ApplyReviewedFilter(ref queryable, true);
+
+            // apply desired found state
+            MetadataFilters.ApplyFoundFilter(ref queryable, "don't know");
+
+            // apply timeframe filter
+            MetadataFilters.ApplyTimeframeFilter(ref queryable, queryParameters.Timeframe, queryParameters.DateFrom, queryParameters.DateTo);
+
+            // apply location and hydrophone filters
+            ApplyOptionalLocationAndHydrophoneFilters(ref queryable, queryParameters);
+
+            // If no detections found
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
+
+            // total number of records
+            double recordCount = queryable.Count();
+
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
+
+            // apply sort, pagination filters and set page count headers
+            ApplySortPaginationAndHeaders(ref results, recordCount, queryParameters);
+
+            // map to returnable data type and return
+            return Ok(results);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
+
+    /// <summary>
+    /// Updates the detection with information provided by a human moderator.
+    /// </summary>
+    /// <param name="id">Detection's unique Id (AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA).</param>
+    /// <param name="detectionUpdate">The Detection's values to be updated.</param>
+    [HttpPut("{id}")]
+    [Authorize("Moderators")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the contents of the updated Detection.", typeof(Detection))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "If the user is not logged in.")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "If the user is logged in, but is not an authorized Moderator.")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Indicates the Detection was not found to update.")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public async ValueTask<ActionResult<Detection>> Put(string id, [FromBody] DetectionUpdate detectionUpdate)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentNullException("id");
+
+            if (detectionUpdate == null)
+                throw new ArgumentNullException("postedDetection");
+
+            var metadata = await _repository.GetByIdAsync(id);
+
+            if (metadata == null)
+                return NotFound();
+
+            metadata.comments = detectionUpdate.Comments;
+            metadata.moderator = detectionUpdate.Moderator;
+            metadata.dateModerated = detectionUpdate.Moderated.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+            metadata.reviewed = detectionUpdate.Reviewed;
+            metadata.SRKWFound = (string.IsNullOrWhiteSpace(detectionUpdate.Found)) ? "no" : detectionUpdate.Found.ToLower();
+
+            // Normalize the tags
+            if (!string.IsNullOrWhiteSpace(detectionUpdate.Tags))
+            {
+                var working = detectionUpdate.Tags.Replace(",", ";");
+
+                var tagList = new List<string>();
+                tagList.AddRange(working.Split(';').ToList().Select(x => x.Trim()));
+                metadata.tags = string.Join(";", tagList);
+            }
+            else
+            {
+                metadata.tags = string.Empty;
+            }
+
+            await _repository.CommitAsync();
+
+            return Ok(DetectionProcessors.ToDetection(metadata));
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
+
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/MetricsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/MetricsController.cs
@@ -8,180 +8,180 @@
 [ApiController]
 public class MetricsController : ControllerBase
 {
-	private readonly MetadataRepository _repository;
+    private readonly MetadataRepository _repository;
 
-	public MetricsController(MetadataRepository repository)
-	{
-		_repository = repository;
-	}
+    public MetricsController(MetadataRepository repository)
+    {
+        _repository = repository;
+    }
 
-	private IQueryable<Metadata> BuildQueryableAsync(string timeframe, string moderator = null)
-	{
-		// start with all records
-		var queryable = _repository.GetAll();
+    private IQueryable<Metadata> BuildQueryableAsync(string timeframe, string moderator = null)
+    {
+        // start with all records
+        var queryable = _repository.GetAll();
 
-		// apply timeframe filter
-		MetadataFilters.ApplyTimeframeFilter(ref queryable, timeframe);
+        // apply timeframe filter
+        MetadataFilters.ApplyTimeframeFilter(ref queryable, timeframe);
 
-		// apply moderator filter, if applicable
-		MetadataFilters.ApplyModeratorFilter(ref queryable, moderator);
+        // apply moderator filter, if applicable
+        MetadataFilters.ApplyModeratorFilter(ref queryable, moderator);
 
-		return queryable;
-	}
+        return queryable;
+    }
 
-	/// <summary>
-	/// Fetch system metrics.
-	/// </summary>
-	[HttpGet("system")]
+    /// <summary>
+    /// Fetch system metrics.
+    /// </summary>
+    [HttpGet("system")]
     [AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the system's metrics.", typeof(Metrics))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If there are no metrics for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<Metrics> GetSystemMetrics([FromQuery] MetricsFilterDTO queryParameters)
-	{
-		try
-		{
-			if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
-				throw new ArgumentNullException("Timeframe");
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the system's metrics.", typeof(Metrics))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If there are no metrics for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<Metrics> GetSystemMetrics([FromQuery] MetricsFilterDTO queryParameters)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+                throw new ArgumentNullException("Timeframe");
 
-			var metrics = new Metrics();
+            var metrics = new Metrics();
 
-			metrics.Timeframe = queryParameters.Timeframe;
+            metrics.Timeframe = queryParameters.Timeframe;
 
-			// Build base queryable
-			var queryable = BuildQueryableAsync(queryParameters.Timeframe);
+            // Build base queryable
+            var queryable = BuildQueryableAsync(queryParameters.Timeframe);
 
-			// If not metrics to return
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
+            // If not metrics to return
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
 
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
 
-			// Pull reviewed/unreviewed metrics from querable
-			var reviewed = DetectionProcessors.GetReviewed(results);
+            // Pull reviewed/unreviewed metrics from querable
+            var reviewed = DetectionProcessors.GetReviewed(results);
 
-			metrics.Reviewed = reviewed.ReviewedCount;
-			metrics.Unreviewed = reviewed.UnreviewedCount;
+            metrics.Reviewed = reviewed.ReviewedCount;
+            metrics.Unreviewed = reviewed.UnreviewedCount;
 
-			// Pull results metrics from queryable
-			var detections = DetectionProcessors.GetResults(results);
+            // Pull results metrics from queryable
+            var detections = DetectionProcessors.GetResults(results);
 
-			metrics.ConfirmedDetection = detections.ConfirmedCount;
-			metrics.FalseDetection = detections.FalseCount;
-			metrics.UnknownDetection = detections.UnknownCount;
+            metrics.ConfirmedDetection = detections.ConfirmedCount;
+            metrics.FalseDetection = detections.FalseCount;
+            metrics.UnknownDetection = detections.UnknownCount;
 
-			// Pull comments from queryable
-			metrics.ConfirmedComments = DetectionProcessors.GetComments(results, "yes");
-			metrics.UnconfirmedComments = DetectionProcessors.GetComments(results, "no");
-			metrics.UnconfirmedComments.AddRange(DetectionProcessors.GetComments(results, "don't know"));
-			metrics.UnconfirmedComments = metrics.UnconfirmedComments.OrderByDescending(x => x.Timestamp).ToList();
+            // Pull comments from queryable
+            metrics.ConfirmedComments = DetectionProcessors.GetComments(results, "yes");
+            metrics.UnconfirmedComments = DetectionProcessors.GetComments(results, "no");
+            metrics.UnconfirmedComments.AddRange(DetectionProcessors.GetComments(results, "don't know"));
+            metrics.UnconfirmedComments = metrics.UnconfirmedComments.OrderByDescending(x => x.Timestamp).ToList();
 
-			// Pull tags from queryable
-			metrics.Tags = DetectionProcessors.GetTags(results);
+            // Pull tags from queryable
+            metrics.Tags = DetectionProcessors.GetTags(results);
 
-			return Ok(metrics);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
+            return Ok(metrics);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
 
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
 
-	/// <summary>
-	/// Fetch user metrics.
-	/// </summary>
-	[HttpGet("moderator")]
-	[AllowAnonymous]
-	[SwaggerResponse(StatusCodes.Status200OK, "Returns the user's metrics.", typeof(Metrics))]
-	[SwaggerResponse(StatusCodes.Status204NoContent, "If the user has no activity for the specified timeframe.")]
-	[SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
-	[SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
-	public ActionResult<Metrics> GetModeratorMetrics([FromQuery] ModeratorMetricsFilterDTO queryParameters)
-	{
-		try
-		{
-			if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
-				throw new ArgumentNullException("Timeframe");
+    /// <summary>
+    /// Fetch user metrics.
+    /// </summary>
+    [HttpGet("moderator")]
+    [AllowAnonymous]
+    [SwaggerResponse(StatusCodes.Status200OK, "Returns the user's metrics.", typeof(Metrics))]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "If the user has no activity for the specified timeframe.")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "If the request was malformed (missing parameters).")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
+    public ActionResult<Metrics> GetModeratorMetrics([FromQuery] ModeratorMetricsFilterDTO queryParameters)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+                throw new ArgumentNullException("Timeframe");
 
-			if (string.IsNullOrWhiteSpace(queryParameters.Moderator))
-				throw new ArgumentNullException("Moderator");
+            if (string.IsNullOrWhiteSpace(queryParameters.Moderator))
+                throw new ArgumentNullException("Moderator");
 
-			var metrics = new ModeratorMetrics();
+            var metrics = new ModeratorMetrics();
 
-			metrics.Timeframe = queryParameters.Timeframe;
-			metrics.Moderator = queryParameters.Moderator;
+            metrics.Timeframe = queryParameters.Timeframe;
+            metrics.Moderator = queryParameters.Moderator;
 
-			// Build base queryable
-			var queryable = BuildQueryableAsync(queryParameters.Timeframe, queryParameters.Moderator);
+            // Build base queryable
+            var queryable = BuildQueryableAsync(queryParameters.Timeframe, queryParameters.Moderator);
 
-			// If not metrics to return
-			if (queryable == null || queryable.Count() == 0)
-			{
-				return NoContent();
-			}
+            // If not metrics to return
+            if (queryable == null || queryable.Count() == 0)
+            {
+                return NoContent();
+            }
 
-			var results = queryable
-				.Select(x => DetectionProcessors.ToDetection(x)).ToList();
+            var results = queryable
+                .Select(x => DetectionProcessors.ToDetection(x)).ToList();
 
-			//// Pull reviewed/unreviewed metrics from querable
-			var reviewed = DetectionProcessors.GetReviewed(results);
+            //// Pull reviewed/unreviewed metrics from querable
+            var reviewed = DetectionProcessors.GetReviewed(results);
 
-			metrics.Reviewed = reviewed.ReviewedCount;
-			metrics.Unreviewed = reviewed.UnreviewedCount;
+            metrics.Reviewed = reviewed.ReviewedCount;
+            metrics.Unreviewed = reviewed.UnreviewedCount;
 
-			// Pull results metrics from queryable
-			var detections = DetectionProcessors.GetResults(results);
+            // Pull results metrics from queryable
+            var detections = DetectionProcessors.GetResults(results);
 
-			metrics.ConfirmedDetection = detections.ConfirmedCount;
-			metrics.FalseDetection = detections.FalseCount;
-			metrics.UnknownDetection = detections.UnknownCount;
+            metrics.ConfirmedDetection = detections.ConfirmedCount;
+            metrics.FalseDetection = detections.FalseCount;
+            metrics.UnknownDetection = detections.UnknownCount;
 
-			// Pull comments from queryable
-			metrics.ConfirmedComments = DetectionProcessors.GetComments(results, "yes");
-			metrics.UnconfirmedComments = DetectionProcessors.GetComments(results, "no");
-			metrics.UnconfirmedComments.AddRange(DetectionProcessors.GetComments(results, "don't know"));
-			metrics.UnconfirmedComments = metrics.UnconfirmedComments.OrderByDescending(x => x.Timestamp).ToList();
+            // Pull comments from queryable
+            metrics.ConfirmedComments = DetectionProcessors.GetComments(results, "yes");
+            metrics.UnconfirmedComments = DetectionProcessors.GetComments(results, "no");
+            metrics.UnconfirmedComments.AddRange(DetectionProcessors.GetComments(results, "don't know"));
+            metrics.UnconfirmedComments = metrics.UnconfirmedComments.OrderByDescending(x => x.Timestamp).ToList();
 
-			// Pull tags from queryable
-			metrics.Tags = DetectionProcessors.GetTags(results);
+            // Pull tags from queryable
+            metrics.Tags = DetectionProcessors.GetTags(results);
 
-			return Ok(metrics);
-		}
-		catch (ArgumentNullException ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Detail = ex.Message
-			};
-			return BadRequest(details);
-		}
-		catch (Exception ex)
-		{
-			var details = new ProblemDetails()
-			{
-				Title = ex.GetType().ToString(),
-				Detail = ex.Message
-			};
+            return Ok(metrics);
+        }
+        catch (ArgumentNullException ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Detail = ex.Message
+            };
+            return BadRequest(details);
+        }
+        catch (Exception ex)
+        {
+            var details = new ProblemDetails()
+            {
+                Title = ex.GetType().ToString(),
+                Detail = ex.Message
+            };
 
-			return StatusCode(StatusCodes.Status500InternalServerError, details);
-		}
-	}
+            return StatusCode(StatusCodes.Status500InternalServerError, details);
+        }
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/TagsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/TagsController.cs
@@ -74,7 +74,7 @@ public class TagsController : ControllerBase
             if (detectionsToUpdate.Count() == 0)
                 return NoContent();
 
-            foreach(var detection in detectionsToUpdate)
+            foreach (var detection in detectionsToUpdate)
             {
                 detection.tags = detection.tags.Replace(tagUpdate.OldTag, tagUpdate.NewTag);
             }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Extensions/Authentication.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Extensions/Authentication.cs
@@ -43,7 +43,7 @@ public static class Authentication
     // Set up Swagger so users can use OAuth to authenticate against it
     public static void ConfigureSwagger(this WebApplicationBuilder builder, AppSettings appSettings)
     {
-        var instance = !string.IsNullOrWhiteSpace(appSettings.AzureAd.Instance) ? 
+        var instance = !string.IsNullOrWhiteSpace(appSettings.AzureAd.Instance) ?
             appSettings.AzureAd.Instance : string.Empty;
         var tenantId = !string.IsNullOrWhiteSpace(appSettings.AzureAd.TenantId) ?
             appSettings.AzureAd.TenantId : Guid.NewGuid().ToString();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionFilters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionFilters.cs
@@ -1,47 +1,47 @@
 ﻿namespace AIForOrcas.Server.Helpers;
 
 public static class DetectionFilters
+{
+    public static int DefaultRecordsPerPage = 5;
+
+    public static void ApplyTimestampSortFilter(ref List<Detection> list, string sortOrder)
     {
-	public static int DefaultRecordsPerPage = 5;
+        if (sortOrder == "asc")
+            list = list.OrderBy(x => x.Timestamp)
+                .ThenByDescending(x => x.Confidence)
+                .ThenBy(x => x.Id)
+                .ToList();
 
-	public static void ApplyTimestampSortFilter(ref List<Detection> list, string sortOrder)
-	{
-		if (sortOrder == "asc")
-			list = list.OrderBy(x => x.Timestamp)
-				.ThenByDescending(x => x.Confidence)
-				.ThenBy(x => x.Id)
-				.ToList();
+        if (sortOrder == "desc")
+            list = list.OrderByDescending(x => x.Timestamp)
+                .ThenByDescending(x => x.Confidence)
+                .ThenBy(x => x.Id)
+                .ToList();
+    }
 
-		if (sortOrder == "desc")
-			list = list.OrderByDescending(x => x.Timestamp)
-				.ThenByDescending(x => x.Confidence)
-				.ThenBy(x => x.Id)
-				.ToList();
-	}
+    public static void ApplyConfidenceSortFilter(ref List<Detection> list, string sortOrder)
+    {
+        if (sortOrder == "asc")
+            list = list.OrderBy(x => x.Confidence)
+                .ThenBy(x => x.Timestamp)
+                .ThenBy(x => x.Id)
+                .ToList();
 
-	public static void ApplyConfidenceSortFilter(ref List<Detection> list, string sortOrder)
-	{
-		if (sortOrder == "asc")
-			list = list.OrderBy(x => x.Confidence)
-				.ThenBy(x => x.Timestamp)
-				.ThenBy(x => x.Id)
-				.ToList();
+        if (sortOrder == "desc")
+            list = list.OrderByDescending(x => x.Confidence)
+                .ThenBy(x => x.Timestamp)
+                .ThenBy(x => x.Id)
+                .ToList();
+    }
 
-		if (sortOrder == "desc")
-			list = list.OrderByDescending(x => x.Confidence)
-				.ThenBy(x => x.Timestamp)
-				.ThenBy(x => x.Id)
-				.ToList();
-	}
+    public static void ApplyPaginationFilter(ref List<Detection> list, int page, int take)
+    {
+        var skip = page > 0 ? page - 1 : 0;
+        var recordsPerPage = take > 0 ? take : DefaultRecordsPerPage;
 
-	public static void ApplyPaginationFilter(ref List<Detection> list, int page, int take)
-	{
-		var skip = page > 0 ? page - 1 : 0;
-		var recordsPerPage = take > 0 ? take : DefaultRecordsPerPage;
-
-		list = list
-			.Skip(skip * recordsPerPage)
-			.Take(recordsPerPage)
-			.ToList();
-	}
+        list = list
+            .Skip(skip * recordsPerPage)
+            .Take(recordsPerPage)
+            .ToList();
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionProcessors.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionProcessors.cs
@@ -2,127 +2,127 @@
 
 public static class DetectionProcessors
 {
-	public static (int ReviewedCount, int UnreviewedCount) GetReviewed(List<Detection> list)
-	{
-		var status = list.GroupBy(n => n.Reviewed);
+    public static (int ReviewedCount, int UnreviewedCount) GetReviewed(List<Detection> list)
+    {
+        var status = list.GroupBy(n => n.Reviewed);
 
-		var reviewed = status.Where(x => x.Key == true)
-			.Select(x => x.Count()).FirstOrDefault();
+        var reviewed = status.Where(x => x.Key == true)
+            .Select(x => x.Count()).FirstOrDefault();
 
-		var unreviewed = status.Where(x => x.Key == false)
-			.Select(x => x.Count()).FirstOrDefault();
+        var unreviewed = status.Where(x => x.Key == false)
+            .Select(x => x.Count()).FirstOrDefault();
 
-		return (reviewed, unreviewed);
-	}
+        return (reviewed, unreviewed);
+    }
 
-	public static (int ConfirmedCount, int FalseCount, int UnknownCount) GetResults(List<Detection> list)
-	{
-		// grab results metrics
-		var results = list.GroupBy(n => n.Found);
+    public static (int ConfirmedCount, int FalseCount, int UnknownCount) GetResults(List<Detection> list)
+    {
+        // grab results metrics
+        var results = list.GroupBy(n => n.Found);
 
-		var confirmed = results.Where(x => x.Key == "yes")
-			.Select(x => x.Count()).FirstOrDefault();
+        var confirmed = results.Where(x => x.Key == "yes")
+            .Select(x => x.Count()).FirstOrDefault();
 
-		var unconfirmed = results.Where(x => x.Key == "no")
-			.Select(x => x.Count()).FirstOrDefault();
+        var unconfirmed = results.Where(x => x.Key == "no")
+            .Select(x => x.Count()).FirstOrDefault();
 
-		var unknown = results.Where(x => x.Key == "don't know")
-			.Select(x => x.Count()).FirstOrDefault();
+        var unknown = results.Where(x => x.Key == "don't know")
+            .Select(x => x.Count()).FirstOrDefault();
 
-		return (confirmed, unconfirmed, unknown);
-	}
+        return (confirmed, unconfirmed, unknown);
+    }
 
-	public static List<MetricsComment> GetComments(List<Detection> list, string status)
-	{
-		var results = new List<MetricsComment>();
+    public static List<MetricsComment> GetComments(List<Detection> list, string status)
+    {
+        var results = new List<MetricsComment>();
 
-		list
-			.Where(x => x.Found == status && !string.IsNullOrWhiteSpace(x.Comments))
-			.ToList().ForEach(x =>
-			{
-				results.Add(new MetricsComment()
-				{
-					Comment = x.Comments,
-					Moderator = x.Moderator,
-					Timestamp = x.Moderated,
-					Id = x.Id
-				});
-			});
+        list
+            .Where(x => x.Found == status && !string.IsNullOrWhiteSpace(x.Comments))
+            .ToList().ForEach(x =>
+            {
+                results.Add(new MetricsComment()
+                {
+                    Comment = x.Comments,
+                    Moderator = x.Moderator,
+                    Timestamp = x.Moderated,
+                    Id = x.Id
+                });
+            });
 
-		return results.OrderByDescending(x => x.Timestamp).ToList();
-	}
+        return results.OrderByDescending(x => x.Timestamp).ToList();
+    }
 
-	public static List<MetricsTag> GetTags(List<Detection> list)
-	{
-		var results = new List<MetricsTag>();
+    public static List<MetricsTag> GetTags(List<Detection> list)
+    {
+        var results = new List<MetricsTag>();
 
-		list
-			.Where(x => !string.IsNullOrWhiteSpace(x.Tags))
-			.ToList().ForEach(y =>
-			{
-				var id = y.Id;
-				y.Tags.Split(";")
-				.ToList().ForEach(z =>
-				{
-					var tag = results.Where(t => t.Tag == z.ToUpper()).FirstOrDefault();
-					if (tag != null)
-					{
-						tag.Ids.Add(id);
-					}
-					else
-					{
-						var newTag = new MetricsTag()
-						{
-							Tag = z.ToUpper()
-						};
-						newTag.Ids.Add(id);
-						results.Add(newTag);
-					}
-				});
-			});
+        list
+            .Where(x => !string.IsNullOrWhiteSpace(x.Tags))
+            .ToList().ForEach(y =>
+            {
+                var id = y.Id;
+                y.Tags.Split(";")
+                .ToList().ForEach(z =>
+                {
+                    var tag = results.Where(t => t.Tag == z.ToUpper()).FirstOrDefault();
+                    if (tag != null)
+                    {
+                        tag.Ids.Add(id);
+                    }
+                    else
+                    {
+                        var newTag = new MetricsTag()
+                        {
+                            Tag = z.ToUpper()
+                        };
+                        newTag.Ids.Add(id);
+                        results.Add(newTag);
+                    }
+                });
+            });
 
-		return results.OrderBy(x => x.Tag).ToList();
-	}
+        return results.OrderBy(x => x.Tag).ToList();
+    }
 
-	public static Detection ToDetection(Metadata metadata)
-	{
-		var detection = new Detection()
-		{
-			Id = string.IsNullOrEmpty(metadata.id) ? Guid.NewGuid().ToString() : metadata.id,
-			SpectrogramUri = string.IsNullOrWhiteSpace(metadata.imageUri) ? string.Empty : metadata.imageUri,
-			AudioUri = string.IsNullOrWhiteSpace(metadata.audioUri) ? string.Empty : metadata.audioUri,
-			Reviewed = metadata.reviewed,
-			Confidence = metadata.whaleFoundConfidence,
-			Found = string.IsNullOrWhiteSpace(metadata.SRKWFound) ? "No" : metadata.SRKWFound,
-			Timestamp = metadata.timestamp,
-			Comments = metadata.comments,
-			Tags = metadata.tags,
-			GlobalPredictionLabel = metadata.globalPredictionLabel ?? string.Empty,
-			Moderated = string.IsNullOrWhiteSpace(metadata.dateModerated) ? DateTime.MinValue : DateTime.Parse(metadata.dateModerated),
-			Moderator = metadata.moderator,
-			Location = new DTO.API.Location()
-			{
-				Name = metadata.location.name,
-				Longitude = metadata.location.longitude,
-				Latitude = metadata.location.latitude
-			}
-		};
+    public static Detection ToDetection(Metadata metadata)
+    {
+        var detection = new Detection()
+        {
+            Id = string.IsNullOrEmpty(metadata.id) ? Guid.NewGuid().ToString() : metadata.id,
+            SpectrogramUri = string.IsNullOrWhiteSpace(metadata.imageUri) ? string.Empty : metadata.imageUri,
+            AudioUri = string.IsNullOrWhiteSpace(metadata.audioUri) ? string.Empty : metadata.audioUri,
+            Reviewed = metadata.reviewed,
+            Confidence = metadata.whaleFoundConfidence,
+            Found = string.IsNullOrWhiteSpace(metadata.SRKWFound) ? "No" : metadata.SRKWFound,
+            Timestamp = metadata.timestamp,
+            Comments = metadata.comments,
+            Tags = metadata.tags,
+            GlobalPredictionLabel = metadata.globalPredictionLabel ?? string.Empty,
+            Moderated = string.IsNullOrWhiteSpace(metadata.dateModerated) ? DateTime.MinValue : DateTime.Parse(metadata.dateModerated),
+            Moderator = metadata.moderator,
+            Location = new DTO.API.Location()
+            {
+                Name = metadata.location.name,
+                Longitude = metadata.location.longitude,
+                Latitude = metadata.location.latitude
+            }
+        };
 
-		if (metadata.predictions?.Count > 0)
-		{
-			metadata.predictions.ForEach(x =>
-			{
-				detection.Annotations.Add(new Annotation()
-				{
-					Id = x.id,
-					Confidence = x.confidence,
-					StartTime = x.startTime,
-					EndTime = x.startTime + x.duration,
-					Label = x.label ?? string.Empty,
-				});
-			});
-		}
+        if (metadata.predictions?.Count > 0)
+        {
+            metadata.predictions.ForEach(x =>
+            {
+                detection.Annotations.Add(new Annotation()
+                {
+                    Id = x.id,
+                    Confidence = x.confidence,
+                    StartTime = x.startTime,
+                    EndTime = x.startTime + x.duration,
+                    Label = x.label ?? string.Empty,
+                });
+            });
+        }
 
-		return detection;
-	}
+        return detection;
+    }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/MetadataFilters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/MetadataFilters.cs
@@ -1,10 +1,10 @@
 ﻿namespace AIForOrcas.Server.Helpers;
 
 public static class MetadataFilters
-	{
-		public static int DefaultRecordsPerPage = 5;
+{
+    public static int DefaultRecordsPerPage = 5;
 
-    public static void ApplyTimeframeFilter(ref IQueryable<Metadata> queryable, string timeframe, DateTime? dateFrom=null, DateTime? dateTo=null)
+    public static void ApplyTimeframeFilter(ref IQueryable<Metadata> queryable, string timeframe, DateTime? dateFrom = null, DateTime? dateTo = null)
     {
         if (!string.IsNullOrWhiteSpace(timeframe))
         {
@@ -58,36 +58,36 @@ public static class MetadataFilters
     }
 
     public static void ApplyModeratorFilter(ref IQueryable<Metadata> queryable, string moderator)
-		{
-			if (!string.IsNullOrWhiteSpace(moderator))
-			{
-				queryable = queryable.Where(x => x.moderator == moderator);
-			}
-		}
+    {
+        if (!string.IsNullOrWhiteSpace(moderator))
+        {
+            queryable = queryable.Where(x => x.moderator == moderator);
+        }
+    }
 
-		public static void ApplyLocationFilter(ref IQueryable<Metadata> queryable, string location)
-		{
-			if (!string.IsNullOrWhiteSpace(location))
-			{
-				queryable = queryable.Where(x => x.location.name == location);
-			}
-		}
+    public static void ApplyLocationFilter(ref IQueryable<Metadata> queryable, string location)
+    {
+        if (!string.IsNullOrWhiteSpace(location))
+        {
+            queryable = queryable.Where(x => x.location.name == location);
+        }
+    }
 
-		public static void ApplyHydrophoneIdFilter(ref IQueryable<Metadata> queryable, string hydrophoneId)
-		{
-			if (!string.IsNullOrWhiteSpace(hydrophoneId))
-			{
-				queryable = queryable.Where(x => x.source_guid == hydrophoneId);
-			}
-		}
+    public static void ApplyHydrophoneIdFilter(ref IQueryable<Metadata> queryable, string hydrophoneId)
+    {
+        if (!string.IsNullOrWhiteSpace(hydrophoneId))
+        {
+            queryable = queryable.Where(x => x.source_guid == hydrophoneId);
+        }
+    }
 
-		public static void ApplyReviewedFilter(ref IQueryable<Metadata> queryable, bool reviewed)
-		{
-			queryable = queryable.Where(x => x.reviewed == reviewed);
-		}
+    public static void ApplyReviewedFilter(ref IQueryable<Metadata> queryable, bool reviewed)
+    {
+        queryable = queryable.Where(x => x.reviewed == reviewed);
+    }
 
-		public static void ApplyFoundFilter(ref IQueryable<Metadata> queryable, string foundState)
-		{
-			queryable = queryable.Where(x => x.SRKWFound == foundState);
-		}
-	}
+    public static void ApplyFoundFilter(ref IQueryable<Metadata> queryable, string foundState)
+    {
+        queryable = queryable.Where(x => x.SRKWFound == foundState);
+    }
+}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Program.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Program.cs
@@ -32,7 +32,7 @@ var app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI(c =>
 {
-    var clientId = !string.IsNullOrWhiteSpace(appSettings.AzureAd.ClientId) ? 
+    var clientId = !string.IsNullOrWhiteSpace(appSettings.AzureAd.ClientId) ?
         appSettings.AzureAd.ClientId : Guid.NewGuid().ToString();
 
     c.OAuthClientId(clientId);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/DetectionsControllerTests/Default.GetDetectionByIdAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/DetectionsControllerTests/Default.GetDetectionByIdAsync.cs
@@ -14,7 +14,7 @@
 
             ActionResult<Detection> actionResult =
                 await _controller.GetDetectionByIdAsync(Guid.NewGuid().ToString());
-            
+
 
             var contentResult = actionResult.Result as ObjectResult;
             Assert.IsNotNull(contentResult);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/DetectionsControllerTests/Default.GetPaginatedDetectionsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/DetectionsControllerTests/Default.GetPaginatedDetectionsAsync.cs
@@ -18,7 +18,7 @@
             };
 
             _orchestrationServiceMock.Setup(service =>
-                service.RetrieveFilteredDetectionsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), 
+                service.RetrieveFilteredDetectionsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(),
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(response);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/ModeratorsControllerTests/Default.GetPaginatedDetectionsForGivenTimeframeTagAndModeratorAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/ModeratorsControllerTests/Default.GetPaginatedDetectionsForGivenTimeframeTagAndModeratorAsync.cs
@@ -19,8 +19,8 @@ namespace OrcaHello.Web.Api.Tests.Unit.Controllers
                 Tag = "Tag",
                 Detections = new List<Detection>
                 {
-                    new() { 
-                        State = "Positive", 
+                    new() {
+                        State = "Positive",
                         Id = Guid.NewGuid().ToString(),
                         Moderator = "Moderator",
                         Tags  = new List<string> { "Tag" }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/TagsControllerTests/Default.GetAllTagsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/TagsControllerTests/Default.GetAllTagsAsync.cs
@@ -7,7 +7,7 @@
         {
             TagListResponse response = new()
             {
-                Tags = new List<string>() {  "Tag1", "Tag2" },
+                Tags = new List<string>() { "Tag1", "Tag2" },
                 Count = 2
             };
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/TagsControllerTests/TryCatch.GetTagsForGivenTimeframeAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Controllers/TagsControllerTests/TryCatch.GetTagsForGivenTimeframeAsync.cs
@@ -28,7 +28,7 @@
 
         private async Task ExecuteRetrieveTags(int count, int statusCode)
         {
-            for(int x = 0; x < count; x++)
+            for (int x = 0; x < count; x++)
             {
                 ActionResult<TagListForTimeframeResponse> actionResult =
                     await _controller.GetTagsForGivenTimeframeAsync(DateTime.Now, DateTime.Now.AddDays(1));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/Default.RetrieveFilteredDetectionsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/Default.RetrieveFilteredDetectionsAsync.cs
@@ -27,12 +27,12 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
             };
 
             _metadataServiceMock.Setup(service =>
-                service.RetrievePaginatedMetadataAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), 
+                service.RetrievePaginatedMetadataAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(),
                     It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(expectedResults);
 
             DetectionListResponse result = await _orchestrationService.
-                RetrieveFilteredDetectionsAsync(DateTime.Now, DateTime.Now.AddDays(1), "Positive", "timestamp",true, null!, 1, 10);
+                RetrieveFilteredDetectionsAsync(DateTime.Now, DateTime.Now.AddDays(1), "Positive", "timestamp", true, null!, 1, 10);
 
             Assert.AreEqual(expectedResults.QueryableRecords.Count(), result.Detections.Count);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneOrchestrationServiceTests/Default.RetrieveHydrophoneLocations.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneOrchestrationServiceTests/Default.RetrieveHydrophoneLocations.cs
@@ -7,7 +7,7 @@
         {
             var expectedResults = new QueryableHydrophoneData
             {
-                QueryableRecords = (new List<HydrophoneData> { new() { Attributes = new() { NodeName = "test_id", Name = "test" } } } ).AsQueryable(),
+                QueryableRecords = (new List<HydrophoneData> { new() { Attributes = new() { NodeName = "test_id", Name = "test" } } }).AsQueryable(),
                 TotalCount = 1
             };
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePaginatedMetadataAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePaginatedMetadataAsync.cs
@@ -15,7 +15,7 @@
             };
 
             _storageBrokerMock.Setup(broker =>
-                broker.GetMetadataListFiltered(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), 
+                broker.GetMetadataListFiltered(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                     .ReturnsAsync(expectedResult);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePositiveMetadataForGivenTimeframeAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/Default.RetrievePositiveMetadataForGivenTimeframeAsync.cs
@@ -30,7 +30,7 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
             Assert.AreEqual(expectedResult.PaginatedRecords.Count(), result.QueryableRecords.Count());
 
             _storageBrokerMock.Verify(broker =>
-                broker.GetPositiveMetadataListByTimeframe(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>()),  
+                broker.GetPositiveMetadataListByTimeframe(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>()),
                     Times.Once);
         }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/Default.RetrieveDetectionsForGivenTimeframeTagAndModeratorAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/Default.RetrieveDetectionsForGivenTimeframeTagAndModeratorAsync.cs
@@ -24,7 +24,7 @@
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync(expectedResult);
 
-            DetectionListForModeratorAndTagResponse response = 
+            DetectionListForModeratorAndTagResponse response =
                 await _orchestrationService.RetrieveDetectionsForGivenTimeframeTagAndModeratorAsync(DateTime.Now, DateTime.Now.AddDays(1), "Moderator", "Tag", 1, 10);
 
             Assert.AreEqual(expectedResult.QueryableRecords.Count(), response.Detections.Count());

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/Guards.cs
@@ -8,7 +8,7 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
         public void Guard_AllGuardConditions_Expect_Exception()
         {
             var wrapper = new ModeratorOrchestrationServiceWrapper();
-          
+
             DateTime? invalidDate = DateTime.MinValue;
 
             Assert.ThrowsException<InvalidModeratorOrchestrationException>(() =>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/ModeratorOrchestrationServiceWrapper.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/ModeratorOrchestrationServiceWrapper.cs
@@ -12,7 +12,7 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
         public new void Validate(string propertyValue, string propertyName) =>
             base.Validate(propertyValue, propertyName);
 
-        public new void ValidatePage(int page) => 
+        public new void ValidatePage(int page) =>
             base.ValidatePage(page);
 
         public new void ValidatePageSize(int pageSize) =>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/TagOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/TagOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -10,18 +10,18 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
             var wrapper = new TagOrchestrationServiceWrapper();
             var delegateMock = new Mock<ReturningGenericFunction<TagListResponse>>();
 
-             delegateMock
-                .SetupSequence(p => p())
+            delegateMock
+               .SetupSequence(p => p())
 
-            .Throws(new InvalidTagOrchestrationException())
+           .Throws(new InvalidTagOrchestrationException())
 
-            .Throws(new MetadataValidationException())
-            .Throws(new MetadataDependencyValidationException())
+           .Throws(new MetadataValidationException())
+           .Throws(new MetadataDependencyValidationException())
 
-            .Throws(new MetadataDependencyException())
-            .Throws(new MetadataServiceException())
+           .Throws(new MetadataDependencyException())
+           .Throws(new MetadataServiceException())
 
-            .Throws(new Exception());
+           .Throws(new Exception());
 
             Assert.ThrowsExceptionAsync<TagOrchestrationValidationException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Brokers/Storages/IStorageBroker.Metadatas.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Brokers/Storages/IStorageBroker.Metadatas.cs
@@ -7,7 +7,7 @@
         Task<List<string>> GetTagListByTimeframeAndModerator(DateTime fromDate, DateTime toDate, string moderator);
         Task<ListMetadataAndCount> GetMetadataListByTimeframeAndTag(DateTime fromDate, DateTime toDate,
             List<string> tags, string tagOperator, int page = 1, int pageSize = 10);
-        Task<ListMetadataAndCount> GetPositiveMetadataListByTimeframe(DateTime fromDate, DateTime toDate, 
+        Task<ListMetadataAndCount> GetPositiveMetadataListByTimeframe(DateTime fromDate, DateTime toDate,
             int page = 1, int pageSize = 10);
         Task<ListMetadataAndCount> GetPositiveMetadataListByTimeframeAndModerator(DateTime fromDate, DateTime toDate,
             string moderator, int page = 1, int pageSize = 10);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Brokers/Storages/StorageBroker.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Brokers/Storages/StorageBroker.cs
@@ -10,7 +10,7 @@
         public StorageBroker(AppSettings appSettings)
         {
             _appSettings = appSettings;
-           
+
             _cosmosClient = new CosmosClient(_appSettings.CosmosConnectionString);
 
             Database database;
@@ -20,7 +20,7 @@
                 database = _cosmosClient.GetDatabase(_appSettings.DetectionsDatabaseName);
                 database.ReadAsync().Wait();
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw new Exception($"Database '{_appSettings.DetectionsDatabaseName}' was not found or could not be opened: {exception.Message}");
             }
@@ -30,7 +30,7 @@
                 _detectionsContainer = database.GetContainer(_appSettings.MetadataContainerName);
                 _detectionsContainer.ReadContainerAsync().Wait();
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 throw new Exception($"Container '{_appSettings.MetadataContainerName}' was not found or could not be opened: {exception.Message}.");
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/1HomeController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/1HomeController.cs
@@ -10,7 +10,7 @@
         [SwaggerResponse(StatusCodes.Status200OK, "Indicates the API is operational.")]
 
         [AllowAnonymous]
-        [ExcludeFromCodeCoverage ]
+        [ExcludeFromCodeCoverage]
         public ActionResult<string> Get() =>
             Ok("Welcome to the OrcaHello API v2.0!");
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/3DetectionsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/3DetectionsController.cs
@@ -53,7 +53,7 @@
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "If there is an internal error reading or processing data from the data source.")]
         [AllowAnonymous]
         public async ValueTask<ActionResult<DetectionListForTagResponse>> GetPaginatedDetectionsForGivenTimeframeAndTagAsync(
-            [SwaggerParameter("The desired tag(s) (i.e. tag1,tag2 for AND tag1|tag2 for OR).", Required = true)] string tag, 
+            [SwaggerParameter("The desired tag(s) (i.e. tag1,tag2 for AND tag1|tag2 for OR).", Required = true)] string tag,
             [SwaggerParameter("The start date of the search (MM/DD/YYYY).", Required = true)] DateTime? fromDate,
             [SwaggerParameter("The end date of the search (MM/DD/YYYY).", Required = true)] DateTime? toDate,
             [SwaggerParameter("The page in the list to request.", Required = true)] int page,

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/7TagsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/7TagsController.cs
@@ -53,16 +53,16 @@
             try
             {
                 var tagListForTimeframeResponse = await _tagOrchestrationService.RetrieveTagsForGivenTimePeriodAsync(fromDate, toDate);
-                
+
                 return Ok(tagListForTimeframeResponse);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 if (exception is TagOrchestrationValidationException ||
                     exception is TagOrchestrationDependencyValidationException)
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
 
-                if(exception is TagOrchestrationDependencyException ||
+                if (exception is TagOrchestrationDependencyException ||
                     exception is TagOrchestrationServiceException)
                     return Problem(exception.Message);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.TryCatchValueTaskT.cs
@@ -20,7 +20,7 @@
                     var statusCode = exception1.StatusCode;
                     var innerException = new InvalidHydrophoneException($"Error encountered accessing down range service defined by 'HydrophoneFeedUrl' setting: {exception1.Message}");
 
-                    if(statusCode == HttpStatusCode.BadRequest ||
+                    if (statusCode == HttpStatusCode.BadRequest ||
                         statusCode == HttpStatusCode.NotFound)
                         throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyValidationException>(_logger, innerException);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.cs
@@ -1,5 +1,5 @@
 ﻿namespace OrcaHello.Web.Api.Services
-{ 
+{
     public partial class HydrophoneService : IHydrophoneService
     {
         private readonly IHydrophoneBroker _hydrophoneBroker;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/IMetadataService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/IMetadataService.cs
@@ -7,7 +7,7 @@
         ValueTask<QueryableTagsForTimeframeAndModerator> RetrieveTagsForGivenTimePeriodAndModeratorAsync(DateTime fromDate, DateTime toDate, string moderator);
         ValueTask<QueryableMetadataForTimeframeAndTag> RetrieveMetadataForGivenTimeframeAndTagAsync(DateTime fromDate, DateTime toDate, string tag, int page, int pageSize);
         ValueTask<QueryableMetadataForTimeframe> RetrievePositiveMetadataForGivenTimeframeAsync(DateTime fromDate, DateTime toDate, int page, int pageSize);
-        ValueTask<QueryableMetadataForTimeframeAndModerator> RetrievePositiveMetadataForGivenTimeframeAndModeratorAsync(DateTime fromDate, DateTime toDate, 
+        ValueTask<QueryableMetadataForTimeframeAndModerator> RetrievePositiveMetadataForGivenTimeframeAndModeratorAsync(DateTime fromDate, DateTime toDate,
             string moderator, int page, int pageSize);
         ValueTask<QueryableMetadataForTimeframe> RetrieveNegativeAndUnknownMetadataForGivenTimeframeAsync(DateTime fromDate, DateTime toDate, int page, int pageSize);
         ValueTask<QueryableMetadataForTimeframeAndModerator> RetrieveNegativeAndUnknownMetadataForGivenTimeframeAndModeratorAsync(DateTime fromDate, DateTime toDate,

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.Guards.cs
@@ -28,7 +28,7 @@ namespace OrcaHello.Web.Api.Services
 
             // TODO: Are there any other required fields
 
-            switch(metadata) 
+            switch (metadata)
             {
                 case { } when ValidatorUtilities.IsInvalid(metadata.Id):
                     throw new InvalidMetadataException(LoggingUtilities.MissingRequiredProperty(nameof(metadata.Id)));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.cs
@@ -101,7 +101,7 @@ namespace OrcaHello.Web.Api.Services
         });
 
         public ValueTask<QueryableMetadataFiltered> RetrievePaginatedMetadataAsync(string state, DateTime fromDate, DateTime toDate, string sortBy, bool isDescending, string location, int page, int pageSize) =>
-        TryCatch(async() =>
+        TryCatch(async () =>
         {
             Validate(fromDate, nameof(fromDate));
             Validate(toDate, nameof(toDate));
@@ -394,12 +394,12 @@ namespace OrcaHello.Web.Api.Services
             List<string> tags = new();
             string tagOperator = "";
 
-            if(tag.Contains(','))
+            if (tag.Contains(','))
             {
                 tagOperator = "AND";
                 tags = tag.Split(',').ToList();
-            } 
-            else if(tag.Contains('|'))
+            }
+            else if (tag.Contains('|'))
             {
                 tagOperator = "OR";
                 tags = tag.Split('|').ToList();
@@ -505,7 +505,7 @@ namespace OrcaHello.Web.Api.Services
             };
         }
 
-    [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage]
         private static string GetSortOrder(bool isDescending)
         {
             return isDescending ? "DESC" : "ASC";

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.Guards.cs
@@ -21,15 +21,15 @@ namespace OrcaHello.Web.Api.Services
             if (request is null)
                 throw new NullModerateDetectionRequestException();
 
-            switch(request)
+            switch (request)
             {
                 case { } when request.Ids is null || !request.Ids.Any():
                     throw new InvalidDetectionOrchestrationException(LoggingUtilities.MissingRequiredProperty(nameof(request.Ids)));
 
-                case { } when ValidatorUtilities.IsInvalid(request.State) :
+                case { } when ValidatorUtilities.IsInvalid(request.State):
                     throw new InvalidDetectionOrchestrationException(LoggingUtilities.MissingRequiredProperty(nameof(request.State)));
 
-                case { } when ValidatorUtilities.IsInvalid(request.Moderator) :
+                case { } when ValidatorUtilities.IsInvalid(request.Moderator):
                     throw new InvalidDetectionOrchestrationException(LoggingUtilities.MissingRequiredProperty(nameof(request.Moderator)));
             }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.cs
@@ -43,9 +43,9 @@
                     IntroHtml = attributes.IntroHtml
                 };
 
-                if(attributes.LocationPoint is not null)
+                if (attributes.LocationPoint is not null)
                 {
-                    if(attributes.LocationPoint.Coordinates != null && attributes.LocationPoint.Coordinates.Count == 2)
+                    if (attributes.LocationPoint.Coordinates != null && attributes.LocationPoint.Coordinates.Count == 2)
                     {
                         result.Longitude = attributes.LocationPoint.Coordinates[0];
                         result.Latitude = attributes.LocationPoint.Coordinates[1];

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.cs
@@ -104,7 +104,7 @@
                 Count = candidateRecords.TotalCount,
                 Moderator = moderator
             };
-});
+        });
 
         public ValueTask<CommentListForModeratorResponse> RetrievePositiveCommentsForGivenTimeframeAndModeratorAsync(DateTime? fromDate, DateTime? toDate, string moderator, int page, int pageSize) =>
         TryCatch(async () =>
@@ -131,7 +131,7 @@
                 TotalCount = results.TotalCount,
                 Count = results.QueryableRecords.Count(),
                 Moderator = moderator,
-        
+
             };
         });
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.TryCatchValueTaskT.cs
@@ -10,12 +10,12 @@
             {
                 return await returningGenericFunction();
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 if (exception is InvalidTagOrchestrationException)
                     throw LoggingUtilities.CreateAndLogException<TagOrchestrationValidationException>(_logger, exception);
 
-                if(exception is MetadataValidationException ||
+                if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
                     throw LoggingUtilities.CreateAndLogException<TagOrchestrationDependencyValidationException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.cs
@@ -58,7 +58,7 @@
 
             int totalRemoved = 0;
 
-            foreach(Metadata item in allMetadataWithTag.QueryableRecords)
+            foreach (Metadata item in allMetadataWithTag.QueryableRecords)
             {
                 item.Tags.Remove(tagToRemove);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Comments/Comment.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Comments/Comment.cs
@@ -21,7 +21,7 @@
 
         [SwaggerSchema("Date and time of when the detection was collected.")]
         public DateTime Timestamp { get; set; }
-        
+
         [SwaggerSchema("URI of the detection's audio file (.wav) in blob storage.")]
         public string AudioUri { get; set; }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Detections/DetectionListResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Detections/DetectionListResponse.cs
@@ -16,7 +16,7 @@
     {
         [SwaggerSchema("The starting date of the timeframe.")]
         public DateTime FromDate { get; set; }
-        
+
         [SwaggerSchema("The ending date of the timeframe.")]
         public DateTime ToDate { get; set; }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Hydrophones/HydrophoneListResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Models/Hydrophones/HydrophoneListResponse.cs
@@ -6,7 +6,7 @@
     {
         [SwaggerSchema("The list of hydrophones.")]
         public List<Hydrophone> Hydrophones { get; set; } = new List<Hydrophone>();
-        
+
         [SwaggerSchema("The total number of hydrophones in the list")]
         public int Count { get; set; }
     }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Services/HttpService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Services/HttpService.cs
@@ -6,7 +6,8 @@ namespace OrcaHello.Web.Shared.Services
     public class HttpService : IHttpService
     {
         private readonly HttpClient _httpClient;
-        private JsonSerializerOptions _jsonSerializeOptions = new() { 
+        private JsonSerializerOptions _jsonSerializeOptions = new()
+        {
             PropertyNameCaseInsensitive = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Utilities/ValidatorUtilities.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Utilities/ValidatorUtilities.cs
@@ -10,7 +10,7 @@
         public static bool IsNegative(long input) => input < 0;
         public static bool IsNegative(int input) => input < 0;
         public static bool IsZeroOrLess(int input) => input <= 0;
-        public static bool IsInvalid(Object input) => input == null;
+        public static bool IsInvalid(object input) => input == null;
         public static bool IsInvalid(DateTime input) => input == default(DateTime);
         public static bool IsInvalidGuidString(string input) => !Guid.TryParse(input, out Guid dummy);
         public static string GetInnerMessage(Exception exception) => exception.InnerException.Message;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DashboardViewServiceTests/Default.RetrieveFilteredTagsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DashboardViewServiceTests/Default.RetrieveFilteredTagsAsync.cs
@@ -7,7 +7,7 @@
         {
             TagListForTimeframeResponse expectedResponse = new()
             {
-                Tags = new() {  "Tag 1", "Tag 2" },
+                Tags = new() { "Tag 1", "Tag 2" },
                 FromDate = DateTime.UtcNow.AddDays(-14),
                 ToDate = DateTime.UtcNow,
                 Count = 2

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/Default.ModerateDetectionsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/Default.ModerateDetectionsAsync.cs
@@ -28,7 +28,7 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             {
                 Ids = new() { id },
                 Moderator = "Moderator",
-                DateModerated  = DateTime.UtcNow,
+                DateModerated = DateTime.UtcNow,
                 State = "Positive"
             };
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/Default.RetrieveDetectionAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/Default.RetrieveDetectionAsync.cs
@@ -9,8 +9,8 @@
 
             Detection expectedResponse = new()
             {
-                Id = id, 
-                Moderator = "John Smith", 
+                Id = id,
+                Moderator = "John Smith",
                 Tags = new() { "Tag 1" }
             };
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionViewServiceTests/Default.ModerateDetectionsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionViewServiceTests/Default.ModerateDetectionsAsync.cs
@@ -25,7 +25,7 @@
             _detectionServiceMock.Verify(service =>
                 service.ModerateDetectionsAsync(It.IsAny<ModerateDetectionsRequest>()),
                 Times.Once);
-         }
+        }
 
         [TestMethod]
         public async Task Default_Expect_ModerateDetectionsAsync_EmptyCommentsAndTags()

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/ModeratorServiceTests/Default.GetFilteredDetectionsForTagAndModeratorAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/ModeratorServiceTests/Default.GetFilteredDetectionsForTagAndModeratorAsync.cs
@@ -12,7 +12,7 @@
                     new() { Id = Guid.NewGuid().ToString(), Moderator = "John Smith", Tags = new() { "Tag 1" } }
                 },
                 Moderator = "John Smith",
-                Tag =  "Tag 1"
+                Tag = "Tag 1"
             };
 
             _apiBrokerMock.Setup(broker =>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/Default.RetrieveDetectionsByTagsAsync.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/Default.RetrieveDetectionsByTagsAsync.cs
@@ -9,8 +9,8 @@
             {
                 Detections = new()
                 {
-                    new() { 
-                        Id = Guid.NewGuid().ToString(), 
+                    new() {
+                        Id = Guid.NewGuid().ToString(),
                         Comments = "These are the comments.",
                         Location = new()
                         {
@@ -29,7 +29,7 @@
 
             PaginatedDetectionsByTagsAndDateRequest request = new()
             {
-                Tags = new() { "Tag 1", "Tag 2"},
+                Tags = new() { "Tag 1", "Tag 2" },
                 Logic = LogicalOperator.And,
                 Page = 1,
                 PageSize = 10,

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/Guards.cs
@@ -6,7 +6,7 @@
         public void Guard_AllGuardConditions_Expect_Exception()
         {
             var wrapper = new TagViewServiceWrapper();
-         
+
             List<string> badIds = null!;
 
             Assert.ThrowsException<InvalidTagViewException>(() =>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/App.razor
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/App.razor
@@ -1,12 +1,12 @@
 ﻿<CascadingAuthenticationState>
-	<Router AppAssembly="@typeof(Program).Assembly">
-		<Found Context="routeData">
-			<AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-		</Found>
-		<NotFound>
-			<LayoutView Layout="@typeof(MainLayout)">
-				<p>Sorry, there's nothing at this address.</p>
-			</LayoutView>
-		</NotFound>
-	</Router>
+    <Router AppAssembly="@typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
 </CascadingAuthenticationState>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Brokers/DetectionAPIBroker/DetectionAPIBroker.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Brokers/DetectionAPIBroker/DetectionAPIBroker.cs
@@ -9,7 +9,7 @@
         public DetectionAPIBroker(IHttpService apiClient, AppSettings appSettings)
         {
             _apiClient = apiClient;
-            _appSettings = appSettings; 
+            _appSettings = appSettings;
         }
 
         private async ValueTask<T> GetAsync<T>(string relativeUrl) =>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Brokers/DetectionAPIBroker/IDetectionAPIBroker.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Brokers/DetectionAPIBroker/IDetectionAPIBroker.cs
@@ -1,5 +1,5 @@
 ﻿namespace OrcaHello.Web.UI.Brokers
-{ 
+{
     public partial interface IDetectionAPIBroker
     {
     }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/Configurations/AuthenticationServiceProviders.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/Configurations/AuthenticationServiceProviders.cs
@@ -20,7 +20,7 @@
         public static void ConfigureAuthProviders(this WebApplicationBuilder builder)
         {
             builder.Services.AddScoped<ApiAuthenticationStateProvider>();
-            builder.Services.AddScoped<AuthenticationStateProvider>(provider => 
+            builder.Services.AddScoped<AuthenticationStateProvider>(provider =>
                 provider.GetRequiredService<ApiAuthenticationStateProvider>());
             builder.Services.AddScoped<IAccountService, AccountService>();
         }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/Requests/ModerateDetectionRequest.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/Requests/ModerateDetectionRequest.cs
@@ -3,7 +3,7 @@
     [ExcludeFromCodeCoverage]
     public class ModerateDetectionRequest
     {
-        public string Id { get; set; } = null!; 
+        public string Id { get; set; } = null!;
         public string State { get; set; } = null!;
         public string Comments { get; set; } = null!;
         public string Moderator { get; set; } = null!;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewItems/DetectionItemView.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewItems/DetectionItemView.cs
@@ -155,7 +155,7 @@
                  SpectrogramUri = detection.SpectrogramUri,
                  Confidence = detection.Confidence,
                  State = detection.State,
-                 Location = LocationItemView.AsLocationItemView(detection.Location), 
+                 Location = LocationItemView.AsLocationItemView(detection.Location),
                  Comments = detection.Comments,
                  Moderator = detection.Moderator,
                  Moderated = detection.Moderated,

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewStates/CommentStateView.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewStates/CommentStateView.cs
@@ -16,7 +16,7 @@
         {
             IsExpanded = !IsExpanded;
 
-            if(IsExpanded && Items == null)
+            if (IsExpanded && Items == null)
             {
                 Items = new();
                 Page = 1;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/AuthenticationComponent.razor
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/AuthenticationComponent.razor
@@ -1,7 +1,7 @@
 ﻿@inherits ComponentManager
 
 <AuthorizeView>
-	<Authorized>
+    <Authorized>
         <RadzenProfileMenu Click="OnProfileMenuClicked">
             <Template>
                 <RadzenStack Orientation=Orientation.Horizontal AlignItems=AlignItems.Center>
@@ -14,8 +14,8 @@
                 <RadzenProfileMenuItem Text="Log Out" onclick="" Icon="logout" />
             </ChildContent>
         </RadzenProfileMenu>
-	</Authorized>
-	<NotAuthorized>
-		<RadzenButton Text="Log In" Click=Login Variant=Variant.Outlined ButtonStyle=ButtonStyle.Primary Style="margin-right:10px;" />
-	</NotAuthorized>
+    </Authorized>
+    <NotAuthorized>
+        <RadzenButton Text="Log In" Click=Login Variant=Variant.Outlined ButtonStyle=ButtonStyle.Primary Style="margin-right:10px;" />
+    </NotAuthorized>
 </AuthorizeView>

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/AuthenticationComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/AuthenticationComponent.razor.cs
@@ -22,7 +22,7 @@
                 // the user's token has not expired. Right now we are checking once
                 // a minute. We can adjust it to longer if need be.
 
-                _timer = new System.Timers.Timer(60000); 
+                _timer = new System.Timers.Timer(60000);
                 _timer.Elapsed += OnTimerElapsed;
                 _timer.Start();
             }
@@ -40,7 +40,7 @@
 
         private async Task OnProfileMenuClicked(RadzenProfileMenuItem item)
         {
-            if(item.Text == "Log Out")
+            if (item.Text == "Log Out")
             {
                 bool? result = await DialogService.Confirm("Select \"Log Out\" below if you are ready to end your current session.", "Ready to Leave?", new ConfirmOptions() { OkButtonText = "Log Out", CancelButtonText = "Cancel" });
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/InlinePlayerComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Components/InlinePlayerComponent.razor.cs
@@ -10,7 +10,7 @@
         public string SpectrogramUri { get; set; } = string.Empty;
 
         [Parameter]
-        public string Id { get; set; } = string.Empty;  
+        public string Id { get; set; } = string.Empty;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/DetectionMetricsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/DetectionMetricsComponent.razor.cs
@@ -4,7 +4,7 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
 {
     [ExcludeFromCodeCoverage]
     public partial class DetectionMetricsComponent
-    { 
+    {
         [Inject]
         public IDashboardViewService ViewService { get; set; } = null!;
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/PositiveCommentsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/PositiveCommentsComponent.razor.cs
@@ -77,7 +77,7 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
                 // Update the count
                 StateView.Count = response.Count;
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 LogAndReportUnknownException(exception);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/TagsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/TagsComponent.razor.cs
@@ -81,7 +81,7 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
                     : await ViewService.RetrieveFilteredTagsAsync(request);
                 StateView.Count = StateView.Items.Count;
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 LogAndReportUnknownException(exception);
             }
@@ -117,7 +117,7 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
                 // Update the count
                 TagDetectionsState.Count = result.Count;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 ReportError("Trouble loading Tag Detections data", ex.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/GridViewComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/GridViewComponent.razor.cs
@@ -250,7 +250,7 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 PillCount = result.Count;
                 await PillCountChanged.InvokeAsync(PillCount);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 // Handle data entry validation errors
                 if (exception is DetectionViewValidationException ||

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/OrcaSounds.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/OrcaSounds.razor.cs
@@ -100,7 +100,7 @@
             LocationDropdownOptions.Add(new(index, "All"));
             SelectedLocation = index;
 
-             SelectedDetectionState = DetectionState.Unreviewed;
+            SelectedDetectionState = DetectionState.Unreviewed;
 
             SetFilterDefaults();
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/CurateTags.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/CurateTags.razor.cs
@@ -94,7 +94,7 @@
 
                 // Update the TagItemViews collection with the retrieved data
                 TagItemViews = result;
-            } 
+            }
             catch (Exception exception)
             {
                 LogAndReportUnknownException(exception);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/AccountService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/AccountService.cs
@@ -135,7 +135,7 @@
                     }
                 }
             }
-            catch 
+            catch
             {
                 _apiAuthenticationStateProvider.ClearMemoryToken();
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
@@ -28,7 +28,7 @@
             if (string.IsNullOrWhiteSpace(savedToken))
                 return new AuthenticationState(_anonymous);
 
-            _httpClient.DefaultRequestHeaders.Authorization = 
+            _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(_headerName, savedToken);
 
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity(
@@ -160,7 +160,8 @@
                             foreach (var parsedRole in parsedRoles)
                             {
                                 claims.Add(new Claim(ClaimTypes.Role, parsedRole));
-                            };
+                            }
+                            ;
                         }
                     }
                     else

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
@@ -161,7 +161,6 @@
                             {
                                 claims.Add(new Claim(ClaimTypes.Role, parsedRole));
                             }
-                            ;
                         }
                     }
                     else

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/IAccountService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/IAccountService.cs
@@ -1,5 +1,5 @@
 ﻿namespace OrcaHello.Web.UI.Services
-{ 
+{
     public interface IAccountService
     {
         Task Login();

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.Guards.cs
@@ -15,7 +15,7 @@
             if (fromDate.Value > DateTime.UtcNow)
                 throw new InvalidCommentException("Property 'fromDate' cannot be in the future.");
 
-            if(!toDate.HasValue)
+            if (!toDate.HasValue)
                 throw new InvalidCommentException("Property 'toDate' cannot be null.");
 
             if (toDate.Value < fromDate.Value)

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/ICommentService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/ICommentService.cs
@@ -1,5 +1,5 @@
 ﻿namespace OrcaHello.Web.UI.Services
-{ 
+{
     public interface ICommentService
     {
         ValueTask<CommentListResponse> RetrieveFilteredPositiveCommentsAsync(DateTime? fromDate, DateTime? toDate, int page, int pageSize);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.Guards.cs
@@ -59,7 +59,7 @@
         // RULE: Response cannot be null.
         protected void ValidateResponse<T>(T response)
         {
-             if (response == null)
+            if (response == null)
             {
                 throw new NullDashboardViewResponseException(nameof(T));
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.cs
@@ -217,23 +217,23 @@
         /// <exception cref="NullDashboardViewRequestException">If the request is null.</exception>
         /// <exception cref="InvalidDashboardViewException">If the moderator is invalid or the request is improperly formatted.</exception>
         /// <exception cref="NullDashboardViewResponseException">If the response from ModeratorService is null.</exception>
-       public ValueTask<ModeratorMetricsItemViewResponse> RetrieveFilteredMetricsForModeratorAsync(string moderator, MetricsByDateRequest request) =>
-        TryCatch(async () =>
-        {
-            ValidateRequest(request);
-            ValidateModerator(moderator);
-            ValidateDateRange(request.FromDate, request.ToDate);
+        public ValueTask<ModeratorMetricsItemViewResponse> RetrieveFilteredMetricsForModeratorAsync(string moderator, MetricsByDateRequest request) =>
+         TryCatch(async () =>
+         {
+             ValidateRequest(request);
+             ValidateModerator(moderator);
+             ValidateDateRange(request.FromDate, request.ToDate);
 
-            MetricsForModeratorResponse response =
-                await _moderatorService.GetFilteredMetricsForModeratorAsync(
-                    moderator: moderator,
-                    fromDate: request.FromDate,
-                    toDate: request.ToDate);
+             MetricsForModeratorResponse response =
+                 await _moderatorService.GetFilteredMetricsForModeratorAsync(
+                     moderator: moderator,
+                     fromDate: request.FromDate,
+                     toDate: request.ToDate);
 
-            ValidateResponse(response);
+             ValidateResponse(response);
 
-            return AsModeratorMetricsItemViewResponse(response);
-        });
+             return AsModeratorMetricsItemViewResponse(response);
+         });
 
         /// <summary>
         /// Retrieves a list of positive comments for a moderator from ModeratorService, filtered by the date range
@@ -352,7 +352,7 @@
             FromDate = metricsResponse.FromDate,
             ToDate = metricsResponse.ToDate,
             Moderator = metricsResponse.Moderator,
-            };
+        };
 
         #endregion
     }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.Guards.cs
@@ -26,7 +26,7 @@
             if (items == null || !items.Any())
                 throw new InvalidDetectionException($"Property '{propertyName}' must not be null and contain at least one value.");
 
-            foreach(var item in items)
+            foreach (var item in items)
             {
                 if (ValidatorUtilities.IsInvalid(item))
                     throw new InvalidDetectionException($"Property '{propertyName}' contains at least one empty or non-string value.");

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.Guards.cs
@@ -15,7 +15,7 @@
             if (ids == null || !ids.Any())
                 throw new InvalidDetectionViewException("At least one 'Id' must be provided.");
 
-            foreach(var id in ids)
+            foreach (var id in ids)
             {
                 if (String.IsNullOrWhiteSpace(id))
                     throw new InvalidDetectionViewException("At least one 'Id' is either null, empty, or whitespace.");

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.cs
@@ -74,7 +74,7 @@
         /// <returns>A <see cref="ValueTask{TResult}"/> that represents the asynchronous operation.</returns>
         /// <exception cref="InvalidDetectionViewException">If one of the passed parameters is null or invalid.</exception>
         /// <exception cref="NullDetectionViewResponseException">If the response from DetectionService is null.</exception>
-        public ValueTask<ModerateDetectionsResponse> ModerateDetectionsAsync(List<string> ids, string state, string moderator, 
+        public ValueTask<ModerateDetectionsResponse> ModerateDetectionsAsync(List<string> ids, string state, string moderator,
             string comments, string tags) =>
         TryCatch(async () =>
         {
@@ -97,7 +97,7 @@
                 Tags = tagsList
             };
 
-            ModerateDetectionsResponse response = 
+            ModerateDetectionsResponse response =
                 await _detectionService.ModerateDetectionsAsync(request);
 
             ValidateResponse(response);
@@ -149,10 +149,12 @@
                 SpectrogramUri = detection.SpectrogramUri,
                 Confidence = detection.Confidence,
                 State = detection.State,
-                Location = new() { 
+                Location = new()
+                {
                     Name = detection.Location.Name,
                     Longitude = detection.Location.Longitude,
-                    Latitude = detection.Location.Latitude },
+                    Latitude = detection.Location.Latitude
+                },
                 Comments = detection.Comments,
                 Moderator = detection.Moderator,
                 Moderated = detection.Moderated,

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.cs
@@ -30,7 +30,8 @@
         /// <exception cref="InvalidHydrophoneException">If the API returns no hydrophones (empty list).</exception>
         /// <exception cref="NullHydrophoneResponseException">If the response from the API is null.</exception>
         public ValueTask<List<Hydrophone>> RetrieveAllHydrophonesAsync() =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
 
             HydrophoneListResponse response = await _apiBroker.GetAllHydrophonesAsync();
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.cs
@@ -32,7 +32,6 @@
         public ValueTask<List<Hydrophone>> RetrieveAllHydrophonesAsync() =>
         TryCatch(async () =>
         {
-
             HydrophoneListResponse response = await _apiBroker.GetAllHydrophonesAsync();
 
             ValidateResponse(response);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.Guards.cs
@@ -32,7 +32,7 @@
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
-             if (page <= 0)
+            if (page <= 0)
                 throw new InvalidModeratorException("Property 'page' number must be positive.");
 
             if (pageSize <= 0)

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.cs
@@ -40,7 +40,6 @@
         DateTime? fromDate, DateTime? toDate, int page, int pageSize) =>
         TryCatch(async () =>
         {
-
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
             ValidatePagination(page, pageSize);
@@ -72,7 +71,6 @@
            DateTime? fromDate, DateTime? toDate, int page, int pageSize) =>
         TryCatch(async () =>
         {
-
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
             ValidatePagination(page, pageSize);
@@ -101,7 +99,6 @@
            DateTime? fromDate, DateTime? toDate) =>
         TryCatch(async () =>
         {
-
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
 
@@ -159,7 +156,6 @@
            DateTime? fromDate, DateTime? toDate) =>
         TryCatch(async () =>
         {
-
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.cs
@@ -38,7 +38,8 @@
         /// <exception cref="NullModeratorResponseException">If the response from the API is null.</exception>
         public ValueTask<CommentListForModeratorResponse> GetFilteredPositiveCommentsForModeratorAsync(string moderator,
         DateTime? fromDate, DateTime? toDate, int page, int pageSize) =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
 
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
@@ -69,7 +70,8 @@
         /// <exception cref="NullModeratorResponseException">If the response from the API is null.</exception>
         public ValueTask<CommentListForModeratorResponse> GetFilteredNegativeAndUknownCommentsForModeratorAsync(string moderator,
            DateTime? fromDate, DateTime? toDate, int page, int pageSize) =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
 
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
@@ -97,15 +99,16 @@
         /// <exception cref="NullModeratorResponseException">If the response from the API is null.</exception>
         public ValueTask<TagListForModeratorResponse> GetFilteredTagsForModeratorAsync(string moderator,
            DateTime? fromDate, DateTime? toDate) =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
 
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
 
             var queryString = $"fromDate={fromDate.GetValueOrDefault()}&toDate={toDate.GetValueOrDefault()}";
 
-             TagListForModeratorResponse response = await _apiBroker
-                .GetFilteredTagsForModeratorAsync(moderator, queryString);
+            TagListForModeratorResponse response = await _apiBroker
+               .GetFilteredTagsForModeratorAsync(moderator, queryString);
 
             ValidateResponse(response);
 
@@ -126,7 +129,8 @@
         /// <exception cref="NullModeratorResponseException">If the response from the API is null.</exception>
         public ValueTask<DetectionListForModeratorAndTagResponse> GetFilteredDetectionsForTagAndModeratorAsync(string moderator, string tag,
             DateTime? fromDate, DateTime? toDate, int page, int pageSize) =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
             Validate(tag, nameof(tag));
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);
@@ -153,7 +157,8 @@
         /// <exception cref="NullModeratorResponseException">If the response from the API is null.</exception>
         public ValueTask<MetricsForModeratorResponse> GetFilteredMetricsForModeratorAsync(string moderator,
            DateTime? fromDate, DateTime? toDate) =>
-        TryCatch(async () => {
+        TryCatch(async () =>
+        {
 
             Validate(moderator, nameof(moderator));
             ValidateDateRange(fromDate, toDate);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/ITagViewService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/ITagViewService.cs
@@ -1,5 +1,5 @@
 ﻿namespace OrcaHello.Web.UI.Services
-{ 
+{
     public interface ITagViewService
     {
         ValueTask<List<TagItemView>> RetrieveAllTagViewsAsync();

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Shared/MainLayout.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Shared/MainLayout.razor.cs
@@ -4,7 +4,7 @@
     public partial class MainLayout
     {
         protected bool sidebarExpanded = true;
-        protected DateTime RightNow = DateTime.UtcNow;        
+        protected DateTime RightNow = DateTime.UtcNow;
         protected bool isSummarySelected = false;
 
         protected override void OnAfterRender(bool firstRender)


### PR DESCRIPTION
Closes #602

Adds a root `.editorconfig` and applies it via `dotnet format` across `ModeratorFrontEnd/AIForOrcas` and `ModeratorFrontEnd/OrcaHello`:

- `indent_style = space`, `indent_size = 4` - 4-space indentation
- `csharp_new_line_before_open_brace = all` - Allman-style braces
- `csharp_space_after_keywords_in_control_flow_statements = true`
- `dotnet_style_predefined_type_for_locals_parameters_members = true : warning` (IDE0049)
- Also converts the 19 `.razor` markup files that `dotnet format` doesn't process
(tabs → 4-space indentation).

Verified with `git diff -w --stat` (only 6 files have non-whitespace changes, all
reviewed) and both solutions build clean.

Left `String.IsNullOrWhiteSpace`/`String.Join` call sites unconverted -
governed by a sibling rule (`dotnet_style_predefined_type_for_member_access`) not named in the issue, can add if wanted.


#603 left for a follow-up PR on this same `.editorconfig`.