### PR TITLE
Add "squeaker" tag to the hierarchy under vessel

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
@@ -157,6 +157,7 @@ namespace AIForOrcas.DTO.API
             { "transient", "orca" },
             { "humpback", "whale" },
             { "vessel", null },
+            { "squeaker", "vessel" },
             { "train", "vessel" },
             { "bird", null },
             { "pigu", "bird" },


### PR DESCRIPTION
At request of Dave Bain.  This adds a short tag for the commonly moderated annotation for a squeaky vessel.

Fixes #585