### PR TITLE
Add braces to single-line control-flow statements in ModeratorFrontEnd

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ indent_size                                                = 4
 dotnet_style_predefined_type_for_locals_parameters_members = true : warning
 csharp_new_line_before_open_brace                          = all
 csharp_space_after_keywords_in_control_flow_statements     = true
+csharp_prefer_braces                                       = true : warning
 
 [*.razor]
 indent_size  = 4

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/EmailHelper.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Helpers/EmailHelper.cs
@@ -6,14 +6,20 @@
         {
             if (string.IsNullOrEmpty(email) ||
                 (!email.Contains("@") && !email.Contains("#")))
+            {
                 return email;
+            }
 
             var working = email;
             if (working.Contains("@"))
+            {
                 working = working.Split('@')[0];
+            }
 
             if (working.Contains("#"))
+            {
                 working = working.Split('#')[1];
+            }
 
             return working;
         }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/AuthTokenProviderExtensions.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/AuthTokenProviderExtensions.cs
@@ -9,7 +9,9 @@ namespace AIForOrcas.Client.BL.Services
         {
             var token = provider.GetToken();
             if (!string.IsNullOrWhiteSpace(token))
+            {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/DetectionService.cs
@@ -54,7 +54,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (string.IsNullOrWhiteSpace(responseString))
+                {
                     return new PaginatedResponseDTO<List<Detection>> { Response = new List<Detection>(), TotalAmountPages = 0, TotalNumberRecords = 0 };
+                }
 
                 // The pagination headers are not guaranteed; a response without
                 // them should not kill the page.

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/MetricsService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/MetricsService.cs
@@ -30,7 +30,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
+                {
                     return new ModeratorMetrics() { HasContent = false };
+                }
 
                 var response = JsonSerializer.Deserialize<ModeratorMetrics>(responseString, defaultJsonSerializerOptions);
                 response.HasContent = true;
@@ -56,7 +58,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NoContent)
+                {
                     return new Metrics() { HasContent = false };
+                }
 
                 var response = JsonSerializer.Deserialize<Metrics>(responseString, defaultJsonSerializerOptions);
                 response.HasContent = true;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/TagService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.BL/Services/TagService.cs
@@ -33,7 +33,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (string.IsNullOrWhiteSpace(responseString))
+                {
                     return new List<string>();
+                }
 
                 return JsonSerializer.Deserialize<List<string>>(responseString, defaultJsonSerializerOptions);
             }
@@ -61,7 +63,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (string.IsNullOrWhiteSpace(responseString))
+                {
                     return 0;
+                }
 
                 return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
             }
@@ -88,7 +92,9 @@ namespace AIForOrcas.Client.BL.Services
                 var responseString = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 if (string.IsNullOrWhiteSpace(responseString))
+                {
                     return 0;
+                }
 
                 return JsonSerializer.Deserialize<int>(responseString, defaultJsonSerializerOptions);
             }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/PaginationComponent.razor.cs
@@ -21,7 +21,9 @@ public partial class PaginationComponent
     private async Task SelectPage(PageLinkDTO link)
     {
         if (link.Page == PaginationResults.CurrentPage || !link.Enabled)
+        {
             return;
+        }
 
         PaginationOptions.Page = link.Page;
         await SelectPageCallback.InvokeAsync(PaginationOptions);

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -60,7 +60,9 @@ public partial class Candidates : IDisposable
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)
+        {
             loadStatus = "An unknown error occurred while loading records...";
+        }
         else if (paginatedResponse.Response.Count == 0)
         {
             loadStatus = pagination.TotalNumberOfRecords == 0

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
@@ -49,9 +49,13 @@ public partial class Confirmed : IDisposable
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)
+        {
             loadStatus = "An unknown error occurred while loading records...";
+        }
         else if (paginatedResponse.Response.Count == 0)
+        {
             loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        }
         else
         {
             loadStatus = null;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
@@ -49,9 +49,13 @@ public partial class FalsePositives : IDisposable
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)
+        {
             loadStatus = "An unknown error occurred while loading records...";
+        }
         else if (paginatedResponse.Response.Count == 0)
+        {
             loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        }
         else
         {
             loadStatus = null;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/SingleDetection.razor.cs
@@ -39,7 +39,9 @@ public partial class SingleDetection : ComponentBase, IDisposable
         detection = await Service.GetDetectionAsync(Id);
         isUnavailable = detection == null;
         if (!isUnavailable && detection.Id == null)
+        {
             isFound = false;
+        }
     }
 
     private async Task ActOnSubmitCallback(DetectionUpdate request)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
@@ -49,9 +49,13 @@ public partial class Unknown : IDisposable
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)
+        {
             loadStatus = "An unknown error occurred while loading records...";
+        }
         else if (paginatedResponse.Response.Count == 0)
+        {
             loadStatus = "No records found for the selected filter options. Please select a different set of filter options...";
+        }
         else
         {
             loadStatus = null;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/AccountService.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/AccountService.cs
@@ -60,15 +60,21 @@ public class AccountService : IAccountService
 
             // Fall back to email claim
             if (string.IsNullOrWhiteSpace(username))
+            {
                 username = user.FindFirst(c => c.Type == "email")?.Value;
+            }
 
             // Fall back to name claim
             if (string.IsNullOrWhiteSpace(username))
+            {
                 username = user.FindFirst(c => c.Type == "name")?.Value;
+            }
 
             // Fall back to identity name
             if (string.IsNullOrWhiteSpace(username))
+            {
                 username = user.Identity.Name;
+            }
 
             return username ?? string.Empty;
         }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/ApiAuthenticationStateProvider.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Services/ApiAuthenticationStateProvider.cs
@@ -145,7 +145,10 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
             var jsonBytes = ParseBase64WithoutPadding(payload);
             var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
 
-            if (keyValuePairs == null) return claims;
+            if (keyValuePairs == null)
+            {
+                return claims;
+            }
 
             // Handle groups.
             if (keyValuePairs.TryGetValue("groups", out object groups) && groups != null)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.DTO/API/Detections/Detection.cs
@@ -93,7 +93,9 @@ namespace AIForOrcas.DTO.API
         public static List<string> GetTagList(string tags)
         {
             if (string.IsNullOrWhiteSpace(tags))
+            {
                 return new List<string>();
+            }
 
             string[] delimiters = new string[] { ";", "," };
             var rawTags = tags.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
@@ -102,7 +104,9 @@ namespace AIForOrcas.DTO.API
             {
                 var trimmed = rawTag.Trim();
                 if (trimmed.Length > 0)
+                {
                     tagList.Add(trimmed);
+                }
             }
             return tagList;
         }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/DetectionsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/DetectionsController.cs
@@ -28,42 +28,64 @@ public class DetectionsController : ControllerBase
     private static void ValidateQueryParameters(DetectionQueryParameters queryParameters)
     {
         if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+        {
             throw new ArgumentNullException("Timeframe");
+        }
 
         if (queryParameters.DateFrom > queryParameters.DateTo)
+        {
             throw new Exception("From Date should be less than To date");
+        }
 
         if (string.IsNullOrWhiteSpace(queryParameters.SortBy))
+        {
             throw new ArgumentNullException("SortBy");
+        }
 
         if (string.IsNullOrWhiteSpace(queryParameters.SortOrder))
+        {
             throw new ArgumentNullException("SortOrder");
+        }
 
         if (string.IsNullOrWhiteSpace(queryParameters.Location))
+        {
             throw new ArgumentNullException("Location");
+        }
 
         if (queryParameters.Page == 0)
+        {
             throw new ArgumentNullException("Page");
+        }
 
         if (queryParameters.RecordsPerPage == 0)
+        {
             throw new ArgumentNullException("RecordsPerPage");
+        }
     }
 
     private static void ApplyOptionalLocationAndHydrophoneFilters(ref IQueryable<Metadata> queryable, DetectionQueryParameters queryParameters)
     {
         if (queryParameters.Location.ToLower() != "all")
+        {
             MetadataFilters.ApplyLocationFilter(ref queryable, queryParameters.Location);
+        }
 
         if (queryParameters.HydrophoneId.ToLower() != "all")
+        {
             MetadataFilters.ApplyHydrophoneIdFilter(ref queryable, queryParameters.HydrophoneId);
+        }
     }
 
     private void ApplySortPaginationAndHeaders(ref List<Detection> results, double recordCount, DetectionQueryParameters queryParameters)
     {
         if (queryParameters.SortBy.ToLower() == "confidence")
+        {
             DetectionFilters.ApplyConfidenceSortFilter(ref results, queryParameters.SortOrder);
+        }
         else if (queryParameters.SortBy.ToLower() == "timestamp")
+        {
             DetectionFilters.ApplyTimestampSortFilter(ref results, queryParameters.SortOrder);
+        }
 
         DetectionFilters.ApplyPaginationFilter(ref results, queryParameters.Page, queryParameters.RecordsPerPage);
 
@@ -151,12 +173,16 @@ public class DetectionsController : ControllerBase
         try
         {
             if (string.IsNullOrWhiteSpace(id))
+            {
                 throw new ArgumentNullException("id");
+            }
 
             var metadata = await _repository.GetByIdAsync(id);
 
             if (metadata == null)
+            {
                 return NotFound();
+            }
 
             return Ok(DetectionProcessors.ToDetection(metadata));
         }
@@ -472,15 +498,21 @@ public class DetectionsController : ControllerBase
         try
         {
             if (string.IsNullOrWhiteSpace(id))
+            {
                 throw new ArgumentNullException("id");
+            }
 
             if (detectionUpdate == null)
+            {
                 throw new ArgumentNullException("postedDetection");
+            }
 
             var metadata = await _repository.GetByIdAsync(id);
 
             if (metadata == null)
+            {
                 return NotFound();
+            }
 
             metadata.comments = detectionUpdate.Comments;
             metadata.moderator = detectionUpdate.Moderator;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/MetricsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/MetricsController.cs
@@ -43,7 +43,9 @@ public class MetricsController : ControllerBase
         try
         {
             if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+            {
                 throw new ArgumentNullException("Timeframe");
+            }
 
             var metrics = new Metrics();
 
@@ -119,10 +121,14 @@ public class MetricsController : ControllerBase
         try
         {
             if (string.IsNullOrWhiteSpace(queryParameters.Timeframe))
+            {
                 throw new ArgumentNullException("Timeframe");
+            }
 
             if (string.IsNullOrWhiteSpace(queryParameters.Moderator))
+            {
                 throw new ArgumentNullException("Moderator");
+            }
 
             var metrics = new ModeratorMetrics();
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/TagsController.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Controllers/TagsController.cs
@@ -28,7 +28,9 @@ public class TagsController : ControllerBase
             var rawTags = _repository.GetAllTags().ToList();
 
             if (rawTags == null || rawTags.Count() == 0)
+            {
                 return NoContent();
+            }
 
             var uniqueTags = new List<string>();
 
@@ -67,12 +69,16 @@ public class TagsController : ControllerBase
         try
         {
             if (tagUpdate == null)
+            {
                 throw new ArgumentNullException("tagUpdate");
+            }
 
             var detectionsToUpdate = _repository.GetAllWithTag(tagUpdate.OldTag).ToList();
 
             if (detectionsToUpdate.Count() == 0)
+            {
                 return NoContent();
+            }
 
             foreach (var detection in detectionsToUpdate)
             {
@@ -120,12 +126,16 @@ public class TagsController : ControllerBase
         try
         {
             if (string.IsNullOrWhiteSpace(tag))
+            {
                 throw new ArgumentNullException("tag");
+            }
 
             var detectionsToUpdate = _repository.GetAllWithTag(tag).ToList();
 
             if (detectionsToUpdate.Count() == 0)
+            {
                 return NoContent();
+            }
 
             foreach (var detection in detectionsToUpdate)
             {

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionFilters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/DetectionFilters.cs
@@ -7,31 +7,39 @@ public static class DetectionFilters
     public static void ApplyTimestampSortFilter(ref List<Detection> list, string sortOrder)
     {
         if (sortOrder == "asc")
+        {
             list = list.OrderBy(x => x.Timestamp)
                 .ThenByDescending(x => x.Confidence)
                 .ThenBy(x => x.Id)
                 .ToList();
+        }
 
         if (sortOrder == "desc")
+        {
             list = list.OrderByDescending(x => x.Timestamp)
                 .ThenByDescending(x => x.Confidence)
                 .ThenBy(x => x.Id)
                 .ToList();
+        }
     }
 
     public static void ApplyConfidenceSortFilter(ref List<Detection> list, string sortOrder)
     {
         if (sortOrder == "asc")
+        {
             list = list.OrderBy(x => x.Confidence)
                 .ThenBy(x => x.Timestamp)
                 .ThenBy(x => x.Id)
                 .ToList();
+        }
 
         if (sortOrder == "desc")
+        {
             list = list.OrderByDescending(x => x.Confidence)
                 .ThenBy(x => x.Timestamp)
                 .ThenBy(x => x.Id)
                 .ToList();
+        }
     }
 
     public static void ApplyPaginationFilter(ref List<Detection> list, int page, int take)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/MetadataFilters.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Server/Helpers/MetadataFilters.cs
@@ -15,11 +15,17 @@ public static class MetadataFilters
                 if (timeframe == "range")
                 {
                     if (dateFrom != null && dateTo != null)
+                    {
                         queryable = queryable.Where(x => x.timestamp >= dateFrom && x.timestamp <= dateTo);
+                    }
                     else if (dateFrom == null && dateTo != null)
+                    {
                         queryable = queryable.Where(x => x.timestamp <= dateTo);
+                    }
                     else if (dateFrom != null && dateTo == null)
+                    {
                         queryable = queryable.Where(x => x.timestamp >= dateFrom);
+                    }
                 }
                 else
                 {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Console.DataMigration/Services/DatabaseMigrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Console.DataMigration/Services/DatabaseMigrationService.cs
@@ -140,7 +140,9 @@ namespace OrcaHello.Console.DataMigration.Services
                     var name = item?.location?.name;
 
                     if (name == "Haro Strait")
+                    {
                         name = "Orcasound Lab";
+                    }
 
                     newItem.locationName = name;
                     newItem.location.name = name;
@@ -149,16 +151,24 @@ namespace OrcaHello.Console.DataMigration.Services
                     // item (Unreviewed, Positive, Negative, Unknown)
 
                     if (!item.reviewed)
+                    {
                         newItem.state = "Unreviewed";
+                    }
 
                     if (item.reviewed && item.SRKWFound == "yes")
+                    {
                         newItem.state = "Positive";
+                    }
 
                     if (item.reviewed && item.SRKWFound == "no")
+                    {
                         newItem.state = "Negative";
+                    }
 
                     if (item.reviewed && item.SRKWFound == "don't know")
+                    {
                         newItem.state = "Unknown";
+                    }
 
                     // We are creating a new partition key
                     PartitionKey partitionKey = new PartitionKey(newItem.state); // Adjust property name

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/CommentOrchestrationTests/TryCatch.CommentListResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/CommentOrchestrationTests/TryCatch.CommentListResponse.cs
@@ -29,12 +29,16 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<CommentOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<CommentOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<CommentOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/DetectionOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -25,16 +25,22 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
            .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionOrchestrationValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<DetectionOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -27,12 +27,16 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<HydrophoneOrchestrationServiceException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/HydrophoneServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -36,18 +36,22 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 9; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneServiceException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
-
-
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/InterestLabelOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/InterestLabelOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -25,16 +25,22 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
            .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<InterestLabelOrchestrationValidationException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<InterestLabelOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<InterestLabelOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<InterestLabelOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetadataServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -44,19 +44,25 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetadataDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 9; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetadataDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<MetadataServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetadataDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<MetadataServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetricsOrchestrationServiceTests/TryCatch.MetricsResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/MetricsOrchestrationServiceTests/TryCatch.MetricsResponse.cs
@@ -29,12 +29,16 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetricOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetricOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<MetricOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/TryCatch.ValueT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/ModeratorOrchestrationServiceTests/TryCatch.ValueT.cs
@@ -30,12 +30,16 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<ModeratorOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<ModeratorOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<ModeratorOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/TagOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api.Tests.Unit/Services/TagOrchestrationServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -27,12 +27,16 @@ namespace OrcaHello.Web.Api.Tests.Unit.Services
                 await wrapper.TryCatch(delegateMock.Object));
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagOrchestrationDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagOrchestrationDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<TagOrchestrationServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/2HydrophonesController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/2HydrophonesController.cs
@@ -33,15 +33,21 @@
             {
                 if (exception is HydrophoneOrchestrationValidationException &&
                     exception.InnerException is InvalidHydrophoneException)
+                {
                     return NotFound(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is HydrophoneOrchestrationValidationException ||
                     exception is HydrophoneOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is HydrophoneOrchestrationDependencyException ||
                     exception is HydrophoneOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/3DetectionsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/3DetectionsController.cs
@@ -32,15 +32,21 @@
             {
                 if (exception is DetectionOrchestrationValidationException &&
                     exception.InnerException is NotFoundMetadataException)
+                {
                     return NotFound(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationValidationException ||
                     exception is DetectionOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationDependencyException ||
                     exception is DetectionOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -69,11 +75,15 @@
             {
                 if (exception is DetectionOrchestrationValidationException ||
                     exception is DetectionOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationDependencyException ||
                     exception is DetectionOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -100,11 +110,15 @@
             {
                 if (exception is DetectionOrchestrationValidationException ||
                     exception is DetectionOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationDependencyException ||
                     exception is DetectionOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -137,11 +151,15 @@
             {
                 if (exception is DetectionOrchestrationValidationException ||
                     exception is DetectionOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationDependencyException ||
                     exception is DetectionOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -168,20 +186,28 @@
             {
                 if (exception is DetectionOrchestrationValidationException &&
                     exception.InnerException is NotFoundMetadataException)
+                {
                     return NotFound(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationValidationException &&
                     (exception.InnerException is DetectionNotDeletedException ||
                     exception.InnerException is DetectionNotInsertedException))
+                {
                     return UnprocessableEntity(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationValidationException ||
                     exception is DetectionOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is DetectionOrchestrationDependencyException ||
                     exception is DetectionOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/4CommentsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/4CommentsController.cs
@@ -34,11 +34,15 @@
             {
                 if (exception is CommentOrchestrationValidationException ||
                     exception is CommentOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is CommentOrchestrationDependencyException ||
                     exception is CommentOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -66,11 +70,15 @@
             {
                 if (exception is CommentOrchestrationValidationException ||
                     exception is CommentOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is CommentOrchestrationDependencyException ||
                     exception is CommentOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/5MetricsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/5MetricsController.cs
@@ -32,11 +32,15 @@
             {
                 if (exception is MetricOrchestrationValidationException ||
                     exception is MetricOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is MetricOrchestrationDependencyException ||
                     exception is MetricOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/6ModeratorsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/6ModeratorsController.cs
@@ -31,11 +31,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -65,11 +69,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -99,11 +107,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -134,11 +146,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -166,11 +182,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -198,11 +218,15 @@
             {
                 if (exception is ModeratorOrchestrationValidationException ||
                     exception is ModeratorOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is ModeratorOrchestrationDependencyException ||
                     exception is ModeratorOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/7TagsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/7TagsController.cs
@@ -30,11 +30,15 @@
             {
                 if (exception is TagOrchestrationValidationException ||
                     exception is TagOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is TagOrchestrationDependencyException ||
                     exception is TagOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -60,11 +64,15 @@
             {
                 if (exception is TagOrchestrationValidationException ||
                     exception is TagOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is TagOrchestrationDependencyException ||
                     exception is TagOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -89,11 +97,15 @@
             {
                 if (exception is TagOrchestrationValidationException ||
                     exception is TagOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is TagOrchestrationDependencyException ||
                     exception is TagOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -118,11 +130,15 @@
             {
                 if (exception is TagOrchestrationValidationException ||
                     exception is TagOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is TagOrchestrationDependencyException ||
                     exception is TagOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/8InterestLabelsController.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Controllers/8InterestLabelsController.cs
@@ -30,11 +30,15 @@
             {
                 if (exception is InterestLabelOrchestrationValidationException ||
                     exception is InterestLabelOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationDependencyException ||
                     exception is InterestLabelOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -61,20 +65,28 @@
             {
                 if (exception is InterestLabelOrchestrationValidationException &&
                     exception.InnerException is NotFoundMetadataException)
+                {
                     return NotFound(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationValidationException &&
                     (exception.InnerException is DetectionNotDeletedException ||
                     exception.InnerException is DetectionNotInsertedException))
+                {
                     return UnprocessableEntity(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationValidationException ||
                     exception is InterestLabelOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationDependencyException ||
                     exception is InterestLabelOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }
@@ -101,15 +113,21 @@
             {
                 if (exception is InterestLabelOrchestrationValidationException &&
                     exception.InnerException is NotFoundMetadataException)
+                {
                     return NotFound(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationValidationException ||
                     exception is InterestLabelOrchestrationDependencyValidationException)
+                {
                     return BadRequest(ValidatorUtilities.GetInnerMessage(exception));
+                }
 
                 if (exception is InterestLabelOrchestrationDependencyException ||
                     exception is InterestLabelOrchestrationServiceException)
+                {
                     return Problem(exception.Message);
+                }
 
                 return Problem(exception.Message);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Hydrophones/HydrophoneService.TryCatchValueTaskT.cs
@@ -13,7 +13,9 @@
             catch (Exception exception)
             {
                 if (exception is InvalidHydrophoneException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneValidationException>(_logger, exception);
+                }
 
                 if (exception is HttpRequestException exception1)
                 {
@@ -22,7 +24,9 @@
 
                     if (statusCode == HttpStatusCode.BadRequest ||
                         statusCode == HttpStatusCode.NotFound)
+                    {
                         throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyValidationException>(_logger, innerException);
+                    }
 
                     if (statusCode == HttpStatusCode.Unauthorized ||
                         statusCode == HttpStatusCode.Forbidden ||
@@ -33,7 +37,9 @@
                         statusCode == HttpStatusCode.RequestTimeout ||
                         statusCode == HttpStatusCode.ServiceUnavailable ||
                         statusCode == HttpStatusCode.InternalServerError)
+                    {
                         throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyException>(_logger, innerException);
+                    }
 
                     throw LoggingUtilities.CreateAndLogException<HydrophoneServiceException>(_logger, innerException);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.Guards.cs
@@ -7,19 +7,25 @@ namespace OrcaHello.Web.Api.Services
         protected void Validate(DateTime date, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(date))
+            {
                 throw new InvalidMetadataException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidMetadataException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void ValidateDatesAreWithinRange(DateTime fromDate, DateTime toDate)
         {
             if (toDate < fromDate)
+            {
                 throw new InvalidMetadataException("'toDate' must be after 'fromDate'.");
+            }
         }
 
         protected void ValidateMetadataOnCreate(Metadata metadata)
@@ -71,8 +77,9 @@ namespace OrcaHello.Web.Api.Services
         protected void ValidateStateIsAcceptable(string state)
         {
             if (ValidatorUtilities.GetMatchingEnumValue(state, typeof(DetectionState)) == null)
+            {
                 throw new InvalidMetadataException($"'{state}' is not a valid Detection state.");
-
+            }
         }
 
         protected void ValidateTagContainsOnlyValidCharacters(string tag)
@@ -82,11 +89,14 @@ namespace OrcaHello.Web.Api.Services
             bool hasInvalidChars = regex.IsMatch(tag);
 
             if (hasInvalidChars)
+            {
                 throw new InvalidMetadataException($"'{tag}' contains one or more invalid characters (use , for AND and use | for OR).");
+            }
 
             if (tag.Contains(',') && tag.Contains('|'))
+            {
                 throw new InvalidMetadataException($"'{tag}' can only work on a single operator (, or |).");
-
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Foundations/Metadatas/MetadataService.TryCatchValueTaskT.cs
@@ -14,7 +14,9 @@
             {
                 if (exception is InvalidMetadataException ||
                     exception is NullMetadataException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetadataValidationException>(_logger, exception);
+                }
 
                 if (exception is CosmosException)
                 {
@@ -25,7 +27,9 @@
 
                     if (statusCode == HttpStatusCode.BadRequest ||
                         statusCode == HttpStatusCode.NotFound)
+                    {
                         throw LoggingUtilities.CreateAndLogException<MetadataDependencyValidationException>(_logger, innerException);
+                    }
 
                     if (statusCode == HttpStatusCode.Unauthorized ||
                         statusCode == HttpStatusCode.Forbidden ||
@@ -36,7 +40,9 @@
                         statusCode == HttpStatusCode.RequestTimeout ||
                         statusCode == HttpStatusCode.ServiceUnavailable ||
                         statusCode == HttpStatusCode.InternalServerError)
+                    {
                         throw LoggingUtilities.CreateAndLogException<MetadataDependencyException>(_logger, innerException);
+                    }
 
                     throw LoggingUtilities.CreateAndLogException<MetadataServiceException>(_logger, innerException);
                 }
@@ -46,7 +52,9 @@
                     exception is HttpRequestException ||
                     exception is AggregateException ||
                     exception is InvalidOperationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetadataDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<MetadataServiceException>(_logger, exception);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Comments/CommentOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Comments/CommentOrchestrationService.Guards.cs
@@ -5,19 +5,25 @@
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidCommentOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void ValidatePage(int page)
         {
             if (ValidatorUtilities.IsZeroOrLess(page))
+            {
                 throw new InvalidCommentOrchestrationException(LoggingUtilities.InvalidProperty("page"));
+            }
         }
 
         protected void ValidatePageSize(int pageSize)
         {
             if (ValidatorUtilities.IsZeroOrLess(pageSize))
+            {
                 throw new InvalidCommentOrchestrationException(LoggingUtilities.InvalidProperty("pageSize"));
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Comments/CommentOrchestrationService.TryCatchCommentListResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Comments/CommentOrchestrationService.TryCatchCommentListResponse.cs
@@ -13,15 +13,21 @@
             catch (Exception exception)
             {
                 if (exception is InvalidCommentOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<CommentOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.Guards.cs
@@ -7,19 +7,25 @@ namespace OrcaHello.Web.Api.Services
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidDetectionOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidDetectionOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void ValidateModerateRequestOnUpdate(ModerateDetectionsRequest request)
         {
             if (request is null)
+            {
                 throw new NullModerateDetectionRequestException();
+            }
 
             switch (request)
             {
@@ -47,19 +53,25 @@ namespace OrcaHello.Web.Api.Services
         protected void ValidatePage(int page)
         {
             if (ValidatorUtilities.IsZeroOrLess(page))
+            {
                 throw new InvalidDetectionOrchestrationException(LoggingUtilities.InvalidProperty("page"));
+            }
         }
 
         protected void ValidatePageSize(int pageSize)
         {
             if (ValidatorUtilities.IsZeroOrLess(pageSize))
+            {
                 throw new InvalidDetectionOrchestrationException(LoggingUtilities.InvalidProperty("pageSize"));
+            }
         }
 
         protected void ValidateStateIsAcceptable(string state)
         {
             if (ValidatorUtilities.GetMatchingEnumValue(state, typeof(DetectionState)) == null)
+            {
                 throw new InvalidDetectionOrchestrationException($"'{state}' is not a valid Detection state.");
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.TryCatchValueTaskT.cs
@@ -16,15 +16,21 @@
                     exception is DetectionNotDeletedException ||
                     exception is DetectionNotInsertedException ||
                     exception is InvalidDetectionOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<DetectionOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Detections/DetectionOrchestrationService.cs
@@ -105,7 +105,9 @@
                 Metadata existingRecord = await _metadataService.RetrieveMetadataByIdAsync(id);
 
                 if (existingRecord is null)
+                {
                     response.IdsNotFound.Add(id);
+                }
                 else
                 {
                     var existingState = existingRecord.State;
@@ -121,7 +123,9 @@
                     bool existingRecordDeleted = await _metadataService.RemoveMetadataByIdAndStateAsync(id, existingState);
 
                     if (!existingRecordDeleted)
+                    {
                         response.IdsUnsuccessfullyUpdated.Add(id);
+                    }
                     else
                     {
                         bool newRecordCreated = await _metadataService.AddMetadataAsync(newRecord);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.TryCatchValueTaskT.cs
@@ -13,15 +13,21 @@
             catch (Exception exception)
             {
                 if (exception is InvalidHydrophoneOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is HydrophoneValidationException ||
                     exception is HydrophoneDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is HydrophoneDependencyException ||
                     exception is HydrophoneServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<HydrophoneOrchestrationServiceException>(_logger, exception);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Hydrohpones/HydrophoneOrchestrationService.cs
@@ -55,7 +55,9 @@
                 return result;
             }
             else
+            {
                 return null!;
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/InterestLabels/InterestLabelOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/InterestLabels/InterestLabelOrchestrationService.Guards.cs
@@ -5,24 +5,32 @@
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidInterestLabelOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void ValidateMetadataFound(Metadata metadata, string id)
         {
             if (metadata is null)
+            {
                 throw new NotFoundMetadataException(id);
+            }
         }
         protected void ValidateDeleted(bool deleted, string id)
         {
             if (!deleted)
+            {
                 throw new DetectionNotDeletedException(id);
+            }
         }
 
         protected void ValidateInserted(bool inserted, string id)
         {
             if (!inserted)
+            {
                 throw new DetectionNotInsertedException(id);
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/InterestLabels/InterestLabelOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/InterestLabels/InterestLabelOrchestrationService.TryCatchValueTaskT.cs
@@ -16,15 +16,21 @@
                     exception is DetectionNotDeletedException ||
                     exception is DetectionNotInsertedException ||
                     exception is InvalidInterestLabelOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<InterestLabelOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<InterestLabelOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<InterestLabelOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<InterestLabelOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Metrics/MetricsOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Metrics/MetricsOrchestrationService.Guards.cs
@@ -5,7 +5,9 @@
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidMetricOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Metrics/MetricsOrchestrationService.TryCatchMetricsResponse.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Metrics/MetricsOrchestrationService.TryCatchMetricsResponse.cs
@@ -13,15 +13,21 @@
             catch (Exception exception)
             {
                 if (exception is InvalidMetricOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<MetricOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.Guards.cs
@@ -5,25 +5,33 @@
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidModeratorOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidModeratorOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void ValidatePage(int page)
         {
             if (ValidatorUtilities.IsZeroOrLess(page))
+            {
                 throw new InvalidModeratorOrchestrationException(LoggingUtilities.InvalidProperty("page"));
+            }
         }
 
         protected void ValidatePageSize(int pageSize)
         {
             if (ValidatorUtilities.IsZeroOrLess(pageSize))
+            {
                 throw new InvalidModeratorOrchestrationException(LoggingUtilities.InvalidProperty("pageSize"));
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Moderators/ModeratorOrchestrationService.TryCatchValueTaskT.cs
@@ -13,15 +13,21 @@
             catch (Exception exception)
             {
                 if (exception is InvalidModeratorOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<ModeratorOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.Guards.cs
@@ -5,13 +5,17 @@
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidTagOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidTagOrchestrationException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
     }
 }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.TryCatchValueTaskT.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.TryCatchValueTaskT.cs
@@ -13,15 +13,21 @@
             catch (Exception exception)
             {
                 if (exception is InvalidTagOrchestrationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagOrchestrationValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataValidationException ||
                     exception is MetadataDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagOrchestrationDependencyValidationException>(_logger, exception);
+                }
 
                 if (exception is MetadataDependencyException ||
                     exception is MetadataServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagOrchestrationDependencyException>(_logger, exception);
+                }
 
                 throw LoggingUtilities.CreateAndLogException<TagOrchestrationServiceException>(_logger, exception);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Api/Services/Orchestrations/Tags/TagOrchestrationService.cs
@@ -65,7 +65,9 @@
                 bool recordUpdated = await _metadataService.UpdateMetadataAsync(item);
 
                 if (recordUpdated)
+                {
                     totalRemoved++;
+                }
             }
 
             TagRemovalResponse result = new()
@@ -99,7 +101,9 @@
                 bool recordUpdated = await _metadataService.UpdateMetadataAsync(item);
 
                 if (recordUpdated)
+                {
                     totalReplaced++;
+                }
             }
 
             TagReplaceResponse result = new()

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Services/HttpService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Services/HttpService.cs
@@ -37,9 +37,13 @@ namespace OrcaHello.Web.Shared.Services
         private Uri NormalizeUrl(string url)
         {
             if (url.ToUpper().StartsWith("HTTP"))
+            {
                 return new Uri(url);
+            }
             else
+            {
                 return new Uri(url, UriKind.Relative);
+            }
         }
 
         public async ValueTask<TResult> PostContentAsync<TContent, TResult>(string url, TContent content)
@@ -54,7 +58,9 @@ namespace OrcaHello.Web.Shared.Services
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             if (ValidationService.OKWithNoContent(responseMessage))
+            {
                 return default(TResult);
+            }
 
             return await Deserialize<TResult>(responseMessage);
         }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Utilities/LoggingUtilities.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.Shared/Utilities/LoggingUtilities.cs
@@ -25,9 +25,13 @@
                 var innerException = exception.InnerException;
 
                 if (innerException is not null)
+                {
                     Log(logger, LogLevel.Warning, exception, innerException.Message);
+                }
                 else
+                {
                     Log(logger, LogLevel.Warning, exception, exception.Message);
+                }
             }
         }
 
@@ -43,9 +47,13 @@
                 var innerException = exception.InnerException;
 
                 if (innerException is not null)
+                {
                     Log(logger, LogLevel.Error, exception, innerException.Message);
+                }
                 else
+                {
                     Log(logger, LogLevel.Error, exception, exception.Message);
+                }
             }
         }
 
@@ -64,7 +72,9 @@
             T exception = (T)Activator.CreateInstance(typeof(T), innerException)!;
 
             if (logger is not null && exception is not null)
+            {
                 LogError(logger, exception as Exception);
+            }
 
             return exception;
         }
@@ -74,7 +84,10 @@
             T exception = (T)Activator.CreateInstance(typeof(T), innerException)!;
 
             if (logger is not null && exception is not null)
+            {
                 LogWarn(logger, exception as Exception);
+            }
+
             return exception;
         }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/CommentServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/CommentServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -28,16 +28,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<CommentValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<CommentDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<CommentDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<CommentServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DashboardViewServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DashboardViewServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -43,16 +43,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
                 .Throws(new Exception());
 
             for (int x = 0; x < 3; x++)
+            {
                 Assert.ThrowsExceptionAsync<DashboardViewValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 10; x++)
+            {
                 Assert.ThrowsExceptionAsync<DashboardViewDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 10; x++)
+            {
                 Assert.ThrowsExceptionAsync<DashboardViewDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<DashboardViewServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -29,16 +29,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 3; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<DetectionServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionViewServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/DetectionViewServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -30,16 +30,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
                 .Throws(new Exception());
 
             for (int x = 0; x < 3; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionViewValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 4; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionViewDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 4; x++)
+            {
                 Assert.ThrowsExceptionAsync<DetectionViewDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<DetectionViewServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/HydrophoneServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/HydrophoneServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -28,16 +28,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<HydrophoneServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/HydrophoneViewServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/HydrophoneViewServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -25,16 +25,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
                 .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneViewValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneViewDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<HydrophoneViewDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<HydrophoneViewServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/MetricsServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/MetricsServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -28,16 +28,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetricsValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetricsDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<MetricsDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<MetricsServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/ModeratorServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/ModeratorServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -28,16 +28,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<ModeratorValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<ModeratorDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<ModeratorDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<ModeratorServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -29,16 +29,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
             .Throws(new Exception());
 
             for (int x = 0; x < 3; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 2; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 5; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<TagServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/TryCatch.ReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI.Tests.Unit/Services/TagViewServiceTests/TryCatch.ReturningGenericFunction.cs
@@ -30,16 +30,22 @@ namespace OrcaHello.Web.UI.Tests.Unit.Services
                 .Throws(new Exception());
 
             for (int x = 0; x < 3; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagViewValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 4; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagViewDependencyValidationException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             for (int x = 0; x < 4; x++)
+            {
                 Assert.ThrowsExceptionAsync<TagViewDependencyException>(async () =>
                     await wrapper.TryCatch(delegateMock.Object));
+            }
 
             Assert.ThrowsExceptionAsync<TagViewServiceException>(async () =>
                 await wrapper.TryCatch(delegateMock.Object));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewItems/DetectionItemView.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Models/ViewItems/DetectionItemView.cs
@@ -88,7 +88,9 @@
             get
             {
                 if (Location is null)
+                {
                     return string.Empty;
+                }
 
                 return $"{Location.Name} ({Location.Latitude.ToString("00.##")}, {Location.Longitude.ToString("00.##")})";
             }
@@ -100,7 +102,9 @@
             get
             {
                 if (string.IsNullOrWhiteSpace(Tags))
+                {
                     return new List<string>();
+                }
 
                 return Tags.Split(',')
                     .Select(s => s.Trim())
@@ -109,7 +113,9 @@
             set
             {
                 if (value != null && value.Count > 0)
+                {
                     Tags = string.Join(',', value);
+                }
             }
         }
 
@@ -135,11 +141,15 @@
                     foreach (var tag in enteredTagsList)
                     {
                         if (!workingTagsList.Contains(tag))
+                        {
                             workingTagsList.Add(tag);
+                        }
                     }
 
                     if (workingTagsList.Count > 0)
+                    {
                         Tags = string.Join(",", workingTagsList);
+                    }
                 }
             }
         }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/DetectionMetricsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/DetectionMetricsComponent.razor.cs
@@ -54,10 +54,14 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
                 // Handle data entry validation errors
                 if (exception is DashboardViewValidationException ||
                     exception is DashboardViewDependencyValidationException)
+                {
                     ValidationMessage = ValidatorUtilities.GetInnerMessage(exception);
+                }
                 else
+                {
                     // Report any other errors as unknown
                     LogAndReportUnknownException(exception);
+                }
             }
             finally
             {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/NegativeAndUnknownCommentsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/NegativeAndUnknownCommentsComponent.razor.cs
@@ -73,7 +73,9 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
 
                 // Update the Data property
                 if (response.CommentItemViews.Any())
+                {
                     StateView.Items.AddRange(response.CommentItemViews);
+                }
 
                 // Update the count
                 StateView.Count = response.Count;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/PositiveCommentsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/PositiveCommentsComponent.razor.cs
@@ -72,7 +72,9 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
 
                 // Update the Data property
                 if (response.CommentItemViews.Any())
+                {
                     StateView.Items.AddRange(response.CommentItemViews);
+                }
 
                 // Update the count
                 StateView.Count = response.Count;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/TagsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Components/TagsComponent.razor.cs
@@ -112,7 +112,9 @@ namespace OrcaHello.Web.UI.Pages.Dashboard.Components
 
                 // Update the Data property
                 if (result.DetectionItemViews.Any())
+                {
                     TagDetectionsState.Items.AddRange(result.DetectionItemViews);
+                }
 
                 // Update the count
                 TagDetectionsState.Count = result.Count;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Metrics.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/Metrics.razor.cs
@@ -74,7 +74,9 @@
             var toDate = SelectedEndDateTime.HasValue ? SelectedEndDateTime.Value : DateTime.UtcNow;
 
             if (SelectedTimeframe != Timeframe.All && SelectedTimeframe != Timeframe.Range)
+            {
                 fromDate = toDate.Adjust(SelectedTimeframe);
+            }
 
             // Reset and close all accordions
             MetricsState.Reset(fromDate, toDate);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/ModeratorMetrics.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Dashboard/ModeratorMetrics.razor.cs
@@ -79,7 +79,9 @@
             var toDate = SelectedEndDateTime.HasValue ? SelectedEndDateTime.Value : DateTime.UtcNow;
 
             if (SelectedTimeframe != Timeframe.All && SelectedTimeframe != Timeframe.Range)
+            {
                 fromDate = toDate.Adjust(SelectedTimeframe);
+            }
 
             // Reset and close all accordions
             MetricsState.Reset(fromDate, toDate);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/BulkReviewComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/BulkReviewComponent.razor.cs
@@ -30,7 +30,10 @@
 
         protected void OnChangeEnteredTags()
         {
-            if (string.IsNullOrWhiteSpace(EnteredTags)) return;
+            if (string.IsNullOrWhiteSpace(EnteredTags))
+            {
+                return;
+            }
 
             var enteredTagsList = EnteredTags
                 .Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
@@ -47,8 +50,9 @@
         protected async Task OnSubmitClicked()
         {
             if (string.IsNullOrEmpty(State))
+            {
                 StateValidationMessage = "You must indicate whether a whale call was heard, not heard, or undetermined for the selected candidates.";
-
+            }
             else
             {
                 var response = await ViewService.ModerateDetectionsAsync(
@@ -59,12 +63,15 @@
                     string.Join(",", SelectedTags));
 
                 if (response.IdsToUpdate.Count == response.IdsSuccessfullyUpdated.Count)
+                {
                     ReportSuccess("Success",
                         "All records successfully updated (and may disappear from this list).");
-
+                }
                 else
+                {
                     ReportError("Failure",
                         "One or more records were not updated.");
+                }
 
                 await OnCloseClicked.InvokeAsync(true);
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/EditableModeratorFieldsComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/EditableModeratorFieldsComponent.razor.cs
@@ -24,7 +24,10 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
 
         protected void OnEnteredTagsChanged()
         {
-            if (string.IsNullOrWhiteSpace(DetectionItemView?.Tags)) return;
+            if (string.IsNullOrWhiteSpace(DetectionItemView?.Tags))
+            {
+                return;
+            }
 
             var enteredTags = DetectionItemView.Tags.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                                               .Select(s => s.Trim())
@@ -38,7 +41,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
         protected async Task OnSubmitClicked()
         {
             if (string.IsNullOrEmpty(DetectionItemView.State) || DetectionItemView.State == DetectionState.Unreviewed.ToString())
+            {
                 StateValidationMessage = "You must indicate whether a whale call was heard, not heard, or undetermined for the selected candidates.";
+            }
             else
             {
                 var response = await ViewService.ModerateDetectionsAsync(
@@ -49,11 +54,15 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                     DetectionItemView.Tags);
 
                 if (response.IdsToUpdate.Count == response.IdsSuccessfullyUpdated.Count)
+                {
                     ReportSuccess("Success",
                         "Record successfully updated (and may disappear from this list).");
+                }
                 else
+                {
                     ReportError("Failure",
                         "Record was not updated.");
+                }
 
                 await ReloadCurrentView.InvokeAsync();
             }

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/GridViewComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/GridViewComponent.razor.cs
@@ -65,7 +65,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 CurrentlySetFilters = Filters;
 
                 if (DetectionDataGrid?.Data != null)
+                {
                     await DetectionDataGrid.Reload();
+                }
             }
         }
 
@@ -81,13 +83,15 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
         public async Task OnReviewClicked()
         {
             if (IsInlineEditing)
+            {
                 ReportError("Inline Edit",
                     "You must complete your inline edit of data before you can perform a bulk review.");
-
+            }
             else if (SelectedDetectionItemViews == null || !SelectedDetectionItemViews.Any())
+            {
                 ReportError("Select a Record",
                     "You must select one or more records to bulk review.");
-
+            }
             else
             {
                 List<string> selectedIds = SelectedDetectionItemViews.Select(x => x.Id).ToList();
@@ -110,7 +114,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
             DialogService.Close();
 
             if (reload)
+            {
                 await ReloadData();
+            }
         }
 
         #endregion
@@ -134,9 +140,10 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
         public async Task OnSaveRowClicked(DetectionItemView item)
         {
             if (string.IsNullOrWhiteSpace(item.State) || item.State == DetectionState.Unreviewed.ToString())
+            {
                 ReportError("Select Call State",
                     "A Call State (Yes, No, Don't Know) must be selected in order to save this record.");
-
+            }
             else
             {
                 var response = await ViewService.ModerateDetectionsAsync(
@@ -151,15 +158,20 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 if (response != null)
                 {
                     if (response.IdsSuccessfullyUpdated.Count > 0)
+                    {
                         ReportSuccess("Success",
                             "Record was successfully updated (and may disappear from this list).");
-
+                    }
                     else if (response.IdsNotFound.Count > 0)
+                    {
                         ReportError("Not Found",
                             "Record not found in the database and could not be updated.");
+                    }
                     else
+                    {
                         ReportError("Failure",
                             "An unknow error occurred while updating the record.");
+                    }
                 }
 
                 await ReloadData();
@@ -180,7 +192,10 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
 
         protected void OnEnteredTagsChanged()
         {
-            if (string.IsNullOrWhiteSpace(ActiveItem?.Tags)) return;
+            if (string.IsNullOrWhiteSpace(ActiveItem?.Tags))
+            {
+                return;
+            }
 
             var enteredTags = ActiveItem.Tags.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                                               .Select(s => s.Trim())
@@ -218,7 +233,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
             var toDate = Filters.EndDateTime.HasValue ? Filters.EndDateTime.Value : DateTime.UtcNow;
 
             if (Filters.Timeframe != Timeframe.All && Filters.Timeframe != Timeframe.Range)
+            {
                 fromDate = toDate.Adjust(Filters.Timeframe);
+            }
 
             int skip = args.Skip.HasValue ? args.Skip.Value : 1;
             int top = args.Top.HasValue ? args.Top.Value : 10;
@@ -255,10 +272,14 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 // Handle data entry validation errors
                 if (exception is DetectionViewValidationException ||
                     exception is DetectionViewDependencyValidationException)
+                {
                     ValidationMessage = ValidatorUtilities.GetInnerMessage(exception);
+                }
                 else
+                {
                     // Report any other errors as unknown
                     LogAndReportUnknownException(exception);
+                }
             }
             finally
             {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/TileViewComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Detections/Components/TileViewComponent.razor.cs
@@ -54,7 +54,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 CurrentlySetFilters = Filters;
 
                 if (DetectionDataList?.Data != null)
+                {
                     await DetectionDataList.Reload();
+                }
             }
         }
 
@@ -85,7 +87,9 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
             var toDate = Filters.EndDateTime.HasValue ? Filters.EndDateTime.Value : DateTime.UtcNow;
 
             if (Filters.Timeframe != Timeframe.All && Filters.Timeframe != Timeframe.Range)
+            {
                 fromDate = toDate.Adjust(Filters.Timeframe);
+            }
 
             int skip = args.Skip.HasValue ? args.Skip.Value : 1;
             int top = args.Top.HasValue ? args.Top.Value : 10;
@@ -122,10 +126,14 @@ namespace OrcaHello.Web.UI.Pages.Detections.Components
                 // Handle data entry validation errors
                 if (exception is DetectionViewValidationException ||
                     exception is DetectionViewDependencyValidationException)
+                {
                     ValidationMessage = ValidatorUtilities.GetInnerMessage(exception);
+                }
                 else
+                {
                     // Report any other errors as unknown
                     LogAndReportUnknownException(exception);
+                }
             }
             finally
             {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/Components/ConfirmDeleteComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/Components/ConfirmDeleteComponent.razor.cs
@@ -36,9 +36,13 @@
 
                 // Check if the tag deletion was successful and report accordingly
                 if (response.MatchingTags == response.ProcessedTags)
+                {
                     ReportSuccess("Success", $"'{Item.Tag}' was successfully deleted from all detections (and will disappear from this list).");
+                }
                 else
+                {
                     ReportError("Failure", $"'{Item.Tag}' was not deleted from one or more detections.");
+                }
 
                 // Invoke the OnCloseClicked event with a parameter indicating success
                 await OnCloseClicked.InvokeAsync(true);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/Components/ReplaceTagComponent.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/Components/ReplaceTagComponent.razor.cs
@@ -56,9 +56,13 @@ namespace OrcaHello.Web.UI.Pages.Tags.Components
 
                 // Check if the tag replacement was successful and report accordingly
                 if (response.MatchingTags == response.ProcessedTags)
+                {
                     ReportSuccess("Success", $"'{request.OldTag}' was successfully replaced with '{request.NewTag}' in all detections.");
+                }
                 else
+                {
                     ReportError("Failure", $"'{request.OldTag}' was not replaced in one or more detections.");
+                }
 
                 // Invoke the OnCloseClicked event with a parameter indicating success
                 await OnCloseClicked.InvokeAsync(true);
@@ -68,10 +72,14 @@ namespace OrcaHello.Web.UI.Pages.Tags.Components
                 // Handle data entry validation errors
                 if (exception is TagViewValidationException ||
                     exception is TagViewDependencyValidationException)
+                {
                     ValidationMessage = ValidatorUtilities.GetInnerMessage(exception);
+                }
                 else
+                {
                     // Report any other errors as unknown
                     LogAndReportUnknownException(exception);
+                }
             }
         }
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/CurateTags.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/CurateTags.razor.cs
@@ -59,7 +59,9 @@
             DialogService.Close();
 
             if (reload)
+            {
                 await ReloadData();
+            }
         }
 
         #endregion

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/TagSearch.razor.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Pages/Tags/TagSearch.razor.cs
@@ -171,7 +171,9 @@
 
             // Now adjust the fromDate if appropriate
             if (SelectedTimeframe != Timeframe.All && SelectedTimeframe != Timeframe.Range)
+            {
                 fromDate = toDate.Adjust(SelectedTimeframe);
+            }
 
             PaginatedDetectionsByTagsAndDateRequest request = new()
             {
@@ -188,7 +190,9 @@
                 var response = await ViewService.RetrieveDetectionsByTagsAsync(request);
 
                 if (response.DetectionItemViews.Any())
+                {
                     DetectionItemViews.AddRange(response.DetectionItemViews);
+                }
 
                 TotalCount = response.Count;
             }
@@ -197,10 +201,14 @@
                 // Handle data entry validation errors
                 if (exception is TagViewValidationException ||
                     exception is TagViewDependencyValidationException)
+                {
                     ValidationMessage = ValidatorUtilities.GetInnerMessage(exception);
+                }
                 else
+                {
                     // Report any other errors as unknown
                     LogAndReportUnknownException(exception);
+                }
             }
 
             IsLoading = false;

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/AccountService/ApiAuthenticationStateProvider.cs
@@ -26,7 +26,9 @@
             var savedToken = await GetToken();
 
             if (string.IsNullOrWhiteSpace(savedToken))
+            {
                 return new AuthenticationState(_anonymous);
+            }
 
             _httpClient.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue(_headerName, savedToken);
@@ -40,7 +42,9 @@
             var memoryToken = _memoryCache.Get<string>(_tokenName);
 
             if (!string.IsNullOrWhiteSpace(memoryToken) && !IsTokenExpired(memoryToken))
+            {
                 return memoryToken;
+            }
 
             if (await IsAppActiveAsync())
             {

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.Guards.cs
@@ -10,26 +10,38 @@
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidCommentException("Property 'fromDate' cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidCommentException("Property 'fromDate' cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidCommentException("Property 'toDate' cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidCommentException("Property 'toDate' cannot be before the 'fromDate'.");
+            }
         }
 
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidCommentException("Property 'page' number must be positive.");
+            }
 
             if (pageSize <= 0)
+            {
                 throw new InvalidCommentException("Property 'pageSize' number must be positive.");
+            }
         }
 
         // RULE: Response cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/CommentService/CommentService.TryCatchReturningGenericFunction.cs
@@ -19,15 +19,21 @@
                 // If the exception is related to invalid or null comments, throw a CommentValidationException
                 if (exception is InvalidCommentException ||
                     exception is NullCommentResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to a conflict in the comment API, throw a CommentDependencyValidationException with an AlreadyExistsCommentException
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentDependencyValidationException>(_logger, new AlreadyExistsCommentException(exception));
+                }
 
                 // If the exception is related to a bad request in the comment API, throw a CommentDependencyValidationException with an InvalidCommentException
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentDependencyValidationException>(_logger, new InvalidCommentException(exception));
+                }
 
                 // If the exception is related to any other HTTP error in the comment API, throw a CommentDependencyException with a FailedCommentDependencyException
                 if (exception is HttpRequestException ||
@@ -35,7 +41,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseInternalServerErrorException ||
                     exception is HttpResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<CommentDependencyException>(_logger, new FailedCommentDependencyException(exception));
+                }
 
                 // If the exception is not handled by any of the above cases, throw a CommentServiceException with a FailedCommentServiceException
                 throw LoggingUtilities.CreateAndLogException<CommentServiceException>(_logger, new FailedCommentServiceException(exception));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.Guards.cs
@@ -10,41 +10,57 @@
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidDashboardViewException("The 'Start' date cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidDashboardViewException("The 'Start' date cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidDashboardViewException("The 'End' date cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidDashboardViewException("The 'End' date cannot be before the 'Start' date.");
+            }
         }
 
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidDashboardViewException("The page number must be positive.");
+            }
 
             // If the pageSize parameter is less than or equal to zero, throw an InvalidDashboardViewException with a custom message.
             if (pageSize <= 0)
+            {
                 throw new InvalidDashboardViewException("The page size must be positive.");
+            }
         }
 
         // RULE: Check if the moderator name is valid.
         protected void ValidateModerator(string moderator)
         {
             if (String.IsNullOrWhiteSpace(moderator))
+            {
                 throw new InvalidDashboardViewException("The moderator name cannot be null, empty, or whitespace.");
+            }
         }
 
         // RULE: Check if the tag is valid.
         protected void ValidateTag(string tag)
         {
             if (String.IsNullOrWhiteSpace(tag))
+            {
                 throw new InvalidDashboardViewException("The tag cannot be null, empty, or whitespace.");
+            }
         }
 
         // RULE: Request cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DashboardViewService/DashboardViewService.TryCatchReturningGenericFunction.cs
@@ -21,7 +21,9 @@
                 if (exception is InvalidDashboardViewException ||
                     exception is NullDashboardViewRequestException ||
                     exception is NullDashboardViewResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DashboardViewValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a DashboardViewDependencyValidationException and log it.
                 // These exceptions indicate that there is something wrong with the validation of the entities or their dependencies that are shown in the dashboard.
@@ -35,7 +37,9 @@
                     exception is CommentDependencyValidationException ||
                     exception is ModeratorValidationException ||
                     exception is ModeratorDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DashboardViewDependencyValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a DashboardViewDependencyException and log it.
                 // These exceptions indicate that there is something wrong with the dependency services or the communication with them.
@@ -49,7 +53,9 @@
                     exception is CommentServiceException ||
                     exception is ModeratorDependencyException ||
                     exception is ModeratorServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DashboardViewDependencyException>(_logger, exception);
+                }
 
                 // If the exception is any other type, rethrow it as a DashboardViewServiceException and log it.
                 // This is a generic exception that indicates that something unexpected happened in the view service.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.Guards.cs
@@ -10,26 +10,34 @@
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidDetectionException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         // RULE: Date must be present and valid
         protected void Validate(DateTime? date, string propertyName)
         {
             if (!date.HasValue || ValidatorUtilities.IsInvalid(date.Value))
+            {
                 throw new InvalidDetectionException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         // RULE: Must be at least one valid id and all ids must be a non-empty string
         protected void ValidateAtLeastOneId(List<string> items, string propertyName)
         {
             if (items == null || !items.Any())
+            {
                 throw new InvalidDetectionException($"Property '{propertyName}' must not be null and contain at least one value.");
+            }
 
             foreach (var item in items)
             {
                 if (ValidatorUtilities.IsInvalid(item))
+                {
                     throw new InvalidDetectionException($"Property '{propertyName}' contains at least one empty or non-string value.");
+                }
             }
         }
 
@@ -37,26 +45,38 @@
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidDetectionException("Property 'fromDate' cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidDetectionException("Property 'fromDate' cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidDetectionException("Property 'toDate' cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidDetectionException("Property 'toDate' cannot be before the 'fromDate'.");
+            }
         }
 
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidDetectionException("Property 'page' number must be positive.");
+            }
 
             if (pageSize <= 0)
+            {
                 throw new InvalidDetectionException("Property 'pageSize' number must be positive.");
+            }
         }
 
         // RULE: Request cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.TryCatchReturningGenericFunction.cs
@@ -20,15 +20,21 @@
                 if (exception is InvalidDetectionException ||
                     exception is NullDetectionRequestException ||
                     exception is NullDetectionResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionValidationException>(_logger, exception);
+                }
 
                 // If the exception is an HttpResponseConflictException, rethrow it as a DetectionDependencyValidationException with an AlreadyExistsTagException as the inner exception
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionDependencyValidationException>(_logger, new AlreadyExistsDetectionException(exception));
+                }
 
                 // If the exception is an HttpResponseBadRequestException, rethrow it as a DetectionDependencyValidationException with an InvalidDetectionException as the inner exception
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionDependencyValidationException>(_logger, new InvalidDetectionException(exception));
+                }
 
                 // If the exception is any of the following types, rethrow it as a DetectionDependencyException with a FailedDetectionDependencyException as the inner exception
                 if (exception is HttpRequestException ||
@@ -36,7 +42,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseInternalServerErrorException ||
                     exception is HttpResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionDependencyException>(_logger, new FailedDetectionDependencyException(exception));
+                }
 
 
                 // If the exception is any other type, rethrow it as a DetectionServiceException with a FailedDetectionServiceException as the inner exception

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionService/DetectionService.cs
@@ -51,7 +51,9 @@
             queryString += $"&page={page}&pageSize={pageSize}";
 
             if (!string.IsNullOrWhiteSpace(location))
+            {
                 queryString += $"&location={location}";
+            }
 
             DetectionListResponse response = await _apiBroker.GetFilteredDetectionsAsync(queryString);
 

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.Guards.cs
@@ -6,19 +6,25 @@
         protected void Validate(string property, string propertyName)
         {
             if (String.IsNullOrWhiteSpace(property))
+            {
                 throw new InvalidDetectionViewException($"{propertyName} cannot be null, empty, or whitespace.");
+            }
         }
 
         // RULE: At least one Id must be provided and no value in the list can be null, empty, or whitespace
         protected void ValidateAtLeastOneId(List<string> ids)
         {
             if (ids == null || !ids.Any())
+            {
                 throw new InvalidDetectionViewException("At least one 'Id' must be provided.");
+            }
 
             foreach (var id in ids)
             {
                 if (String.IsNullOrWhiteSpace(id))
+                {
                     throw new InvalidDetectionViewException("At least one 'Id' is either null, empty, or whitespace.");
+                }
             }
         }
 
@@ -26,16 +32,24 @@
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidDetectionViewException("The 'Start' date cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidDetectionViewException("The 'Start' date cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidDetectionViewException("The 'End' date cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidDetectionViewException("The 'End' date cannot be before the 'Start' date.");
+            }
         }
 
 
@@ -43,10 +57,14 @@
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidDetectionViewException("The page number must be positive.");
+            }
 
             if (pageSize <= 0)
+            {
                 throw new InvalidDetectionViewException("The page size must be positive.");
+            }
         }
 
         // RULE: Request cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/DetectionViewService/DetectionViewService.TryCatchReturningGenericFunction.cs
@@ -23,7 +23,9 @@
                 if (exception is InvalidDetectionViewException ||
                     exception is NullDetectionViewRequestException ||
                     exception is NullDetectionViewResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionViewValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a DetectionViewDependencyValidationException and log it.
                 // These exceptions indicate that there is something wrong with the validation of the Tag entity or its dependencies.
@@ -31,7 +33,9 @@
                     exception is TagValidationException ||
                     exception is DetectionDependencyValidationException ||
                     exception is TagDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionViewDependencyValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a DetectionViewDependencyException and log it.
                 // These exceptions indicate that there is something wrong with the dependency services or the communication with them.
@@ -39,7 +43,9 @@
                     exception is TagDependencyException ||
                     exception is DetectionServiceException ||
                     exception is TagServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<DetectionViewDependencyException>(_logger, exception);
+                }
 
                 // If the exception is any other type, rethrow it as a DetectionViewServiceException and log it.
                 // This is a generic exception that indicates that something unexpected happened in the view service.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneService/HydrophoneService.TryCatchReturningGenericFunction.cs
@@ -21,15 +21,21 @@
                 // it as a HydrophoneValidationException and log it.
                 if (exception is NullHydrophoneResponseException ||
                     exception is InvalidHydrophoneException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to the conflict or bad request of the hydrophone broker, rethrow
                 // it as a HydrophoneDependencyValidationException and log it.
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyValidationException>(_logger, new AlreadyExistsHydrophoneException(exception));
+                }
 
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyValidationException>(_logger, new InvalidHydrophoneException(exception));
+                }
 
                 // If the exception is related to the dependency of the hydrophone broker, rethrow
                 // it as a HydrophoneDependencyException and log it.
@@ -38,7 +44,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseException ||
                     exception is HttpResponseInternalServerErrorException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneDependencyException>(_logger, new FailedHydrophoneDependencyException(exception));
+                }
 
                 // If the exception is any other type, rethrow it as a HydrophoneServiceException and log it.
                 throw LoggingUtilities.CreateAndLogException<HydrophoneServiceException>(_logger, new FailedHydrophoneServiceException(exception));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneViewService/HydrophoneViewService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/HydrophoneViewService/HydrophoneViewService.TryCatchReturningGenericFunction.cs
@@ -20,19 +20,25 @@
                 // it as a HydrophoneViewValidationException and log it.
                 if (exception is NullHydrophoneViewResponseException ||
                     exception is InvalidHydrophoneViewException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneViewValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to the validation of the hydrophone dependency, rethrow
                 // it as a HydrophoneViewDependencyValidationException and log it.
                 if (exception is HydrophoneValidationException ||
                     exception is HydrophoneDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneViewDependencyValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to the dependency of the hydrophone service, rethrow
                 // it as a HydrophoneViewDependencyException and log it.
                 if (exception is HydrophoneDependencyException ||
                     exception is HydrophoneServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<HydrophoneViewDependencyException>(_logger, exception);
+                }
 
                 // If the exception is any other type, rethrow it as a HydrophoneViewServiceException and log it.
                 throw LoggingUtilities.CreateAndLogException<HydrophoneViewServiceException>(_logger, exception);

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/MetricsService/MetricsService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/MetricsService/MetricsService.Guards.cs
@@ -10,16 +10,24 @@
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidMetricsException("Property 'fromDate' cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidMetricsException("Property 'fromDate' cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidMetricsException("Property 'toDate' cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidMetricsException("Property 'toDate' cannot be before the 'fromDate'.");
+            }
         }
 
         // RULE: Response cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/MetricsService/MetricsService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/MetricsService/MetricsService.TryCatchReturningGenericFunction.cs
@@ -19,15 +19,21 @@
                 // If the exception is related to invalid or null metrics, throw a MetricsValidationException
                 if (exception is InvalidMetricsException ||
                     exception is NullMetricsResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricsValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to a conflict in the detection API, throw a MetricsDependencyValidationException with an AlreadyExistsMetricsException
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricsDependencyValidationException>(_logger, new AlreadyExistsMetricsException(exception));
+                }
 
                 // If the exception is related to a bad request in the detection API, throw a MetricsDependencyValidationException with an InvalidMetricsException
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricsDependencyValidationException>(_logger, new InvalidMetricsException(exception));
+                }
 
                 // If the exception is related to any other HTTP error in the detection API, throw a MetricsDependencyException with a FailedMetricsDependencyException
                 if (exception is HttpRequestException ||
@@ -35,7 +41,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseInternalServerErrorException ||
                     exception is HttpResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<MetricsDependencyException>(_logger, new FailedMetricsDependencyException(exception));
+                }
 
                 // If the exception is not handled by any of the above cases, throw a MetricsServiceException with a FailedMetricsServiceException
                 throw LoggingUtilities.CreateAndLogException<MetricsServiceException>(_logger, new FailedMetricsServiceException(exception));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.Guards.cs
@@ -10,33 +10,47 @@
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidModeratorException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         // RULE: Date range must be valid.
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidModeratorException("Property 'fromDate' cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidModeratorException("Property 'fromDate' cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidModeratorException("Property 'toDate' cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidModeratorException("Property 'toDate' cannot be before the 'fromDate'.");
+            }
         }
 
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidModeratorException("Property 'page' number must be positive.");
+            }
 
             if (pageSize <= 0)
+            {
                 throw new InvalidModeratorException("Property 'pageSize' number must be positive.");
+            }
         }
 
         // RULE: Response cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/ModeratorService/ModeratorService.TryCatchReturningGenericFunction.cs
@@ -21,15 +21,21 @@
                 // it as a ModeratorValidationException and log it.
                 if (exception is NullModeratorResponseException ||
                     exception is InvalidModeratorException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorValidationException>(_logger, exception);
+                }
 
                 // If the exception is related to the conflict or bad request of the broker, rethrow
                 // it as a ModeratorDependencyValidationException and log it.
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorDependencyValidationException>(_logger, new AlreadyExistsModeratorException(exception));
+                }
 
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorDependencyValidationException>(_logger, new InvalidModeratorException(exception));
+                }
 
                 // If the exception is related to the dependency of the broker, rethrow
                 // it as a ModeratorDependencyException and log it.
@@ -38,7 +44,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseException ||
                     exception is HttpResponseInternalServerErrorException)
+                {
                     throw LoggingUtilities.CreateAndLogException<ModeratorDependencyException>(_logger, new FailedModeratorDependencyException(exception));
+                }
 
                 // If the exception is any other type, rethrow it as a HydrophoneServiceException and log it.
                 throw LoggingUtilities.CreateAndLogException<ModeratorServiceException>(_logger, new FailedModeratorServiceException(exception));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagService/TagService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagService/TagService.Guards.cs
@@ -10,23 +10,33 @@
         protected void Validate(string propertyValue, string propertyName)
         {
             if (ValidatorUtilities.IsInvalid(propertyValue))
+            {
                 throw new InvalidTagException(LoggingUtilities.MissingRequiredProperty(propertyName));
+            }
         }
 
         // RULE: Date range must be valid.
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidTagException("Property 'fromDate' cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidTagException("Property 'fromDate' cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidTagException("Property 'toDate' cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidTagException("Property 'toDate' cannot be before the 'fromDate'.");
+            }
         }
 
         // RULE: Request cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagService/TagService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagService/TagService.TryCatchReturningGenericFunction.cs
@@ -20,15 +20,21 @@
                 if (exception is InvalidTagException ||
                     exception is NullTagRequestException ||
                     exception is NullTagResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagValidationException>(_logger, exception);
+                }
 
                 // If the exception is an HttpResponseConflictException, rethrow it as a TagDependencyValidationException with an AlreadyExistsTagException as the inner exception
                 if (exception is HttpResponseConflictException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagDependencyValidationException>(_logger, new AlreadyExistsTagException(exception));
+                }
 
                 // If the exception is an HttpResponseBadRequestException, rethrow it as a TagDependencyValidationException with an InvalidTagException as the inner exception
                 if (exception is HttpResponseBadRequestException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagDependencyValidationException>(_logger, new InvalidTagException(exception));
+                }
 
                 // If the exception is any of the following types, rethrow it as a TagDependencyException with a FailedTagDependencyException as the inner exception
                 if (exception is HttpRequestException ||
@@ -36,7 +42,9 @@
                     exception is HttpResponseUnauthorizedException ||
                     exception is HttpResponseInternalServerErrorException ||
                     exception is HttpResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagDependencyException>(_logger, new FailedTagDependencyException(exception));
+                }
 
                 // If the exception is any other type, rethrow it as a TagServiceException with a FailedTagServiceException as the inner exception
                 throw LoggingUtilities.CreateAndLogException<TagServiceException>(_logger, new FailedTagServiceException(exception));

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/TagViewService.Guards.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/TagViewService.Guards.cs
@@ -9,40 +9,56 @@
         protected void ValidateAtLeastOneTagSelected(List<string> tags)
         {
             if (tags == null || !tags.Any())
+            {
                 throw new InvalidTagViewException("At least one 'Tag' must be selected.");
+            }
         }
 
         // RULE: Date range must be valid.
         protected void ValidateDateRange(DateTime? fromDate, DateTime? toDate)
         {
             if (!fromDate.HasValue)
+            {
                 throw new InvalidTagViewException("The 'Start' date cannot be null.");
+            }
 
             if (fromDate.Value > DateTime.UtcNow)
+            {
                 throw new InvalidTagViewException("The 'Start' date cannot be in the future.");
+            }
 
             if (!toDate.HasValue)
+            {
                 throw new InvalidTagViewException("The 'End' date cannot be null.");
+            }
 
             if (toDate.Value < fromDate.Value)
+            {
                 throw new InvalidTagViewException("The 'End' date cannot be before the 'Start' date.");
+            }
         }
 
         // RULE: Pagination must be correct.
         protected void ValidatePagination(int page, int pageSize)
         {
             if (page <= 0)
+            {
                 throw new InvalidTagViewException("The page number must be positive.");
+            }
 
             if (pageSize <= 0)
+            {
                 throw new InvalidTagViewException("The page size must be positive.");
+            }
         }
 
         // RULE: Tag cannot be null, empty, or whitespace.
         protected void ValidateTagString(string tag, string name)
         {
             if (String.IsNullOrWhiteSpace(tag))
+            {
                 throw new InvalidTagViewException($"{name} cannot be null, empty, or whitespace.");
+            }
         }
 
         // RULE: Request cannot be null.

--- a/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/TagViewService.TryCatchReturningGenericFunction.cs
+++ b/ModeratorFrontEnd/OrcaHello/OrcaHello.Web.UI/Services/TagViewService/TagViewService.TryCatchReturningGenericFunction.cs
@@ -23,7 +23,9 @@
                 if (exception is NullTagViewRequestException ||
                     exception is InvalidTagViewException ||
                     exception is NullTagViewResponseException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagViewValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a TagViewDependencyValidationException and log it.
                 // These exceptions indicate that there is something wrong with the validation of the Tag entity or its dependencies.
@@ -31,7 +33,9 @@
                     exception is DetectionValidationException ||
                     exception is TagDependencyValidationException ||
                     exception is DetectionViewDependencyValidationException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagViewDependencyValidationException>(_logger, exception);
+                }
 
                 // If the exception is one of the following types, rethrow it as a TagViewDependencyException and log it.
                 // These exceptions indicate that there is something wrong with the dependency services or the communication with them.
@@ -39,7 +43,9 @@
                     exception is DetectionDependencyException ||
                     exception is TagServiceException ||
                     exception is DetectionServiceException)
+                {
                     throw LoggingUtilities.CreateAndLogException<TagViewDependencyException>(_logger, exception);
+                }
 
                 // If the exception is any other type, rethrow it as a TagViewServiceException and log it.
                 // This is a generic exception that indicates that something unexpected happened in the view service.


### PR DESCRIPTION
Closes #603

Adds `csharp_prefer_braces = true : warning` to `.editorconfig` (extending the config from #602/#607) and runs `dotnet format style` across `ModeratorFrontEnd` to add braces to single-line `if`/`else`/`for`/`foreach`/`while` bodies, per both style guides CONTRIBUTING.md references.
Both solutions build without errors.
