### PR TITLE
Fix stale pager after moderation submit on Confirmed, Unknown, False Positives (#608, #624)

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
@@ -42,6 +42,7 @@ public partial class Confirmed : IDisposable
     private async Task LoadDetections()
     {
         loadStatus = "Loading records...";
+        detections = null;
         var paginatedResponse = await Service.GetConfirmedDetectionsAsync(paginationOptions, filterOptions);
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
@@ -65,7 +66,6 @@ public partial class Confirmed : IDisposable
     private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
     {
         paginationOptions = returnedPaginationOptions;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();
@@ -86,7 +86,6 @@ public partial class Confirmed : IDisposable
     private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
     {
         filterOptions = returnedFilterOptions;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Confirmed.razor.cs
@@ -47,6 +47,15 @@ public partial class Confirmed : IDisposable
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
         pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+
+        if (pagination.TotalNumberOfPages > 0 && paginationOptions.Page > pagination.TotalNumberOfPages)
+        {
+            paginationOptions.Page = pagination.TotalNumberOfPages;
+            paginatedResponse = await Service.GetConfirmedDetectionsAsync(paginationOptions, filterOptions);
+            pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+            pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        }
+
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)
@@ -63,6 +72,7 @@ public partial class Confirmed : IDisposable
             detections = paginatedResponse.Response;
         }
     }
+
     private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
     {
         paginationOptions = returnedPaginationOptions;
@@ -86,6 +96,7 @@ public partial class Confirmed : IDisposable
     private async Task ActOnApplyFilterCallback(ReviewedFilterOptionsDTO returnedFilterOptions)
     {
         filterOptions = returnedFilterOptions;
+        paginationOptions.Page = 1;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
@@ -47,6 +47,15 @@ public partial class FalsePositives : IDisposable
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
         pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+
+        if (pagination.TotalNumberOfPages > 0 && paginationOptions.Page > pagination.TotalNumberOfPages)
+        {
+            paginationOptions.Page = pagination.TotalNumberOfPages;
+            paginatedResponse = await Service.GetFalseDetectionsAsync(paginationOptions, filterOptions);
+            pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+            pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        }
+
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/FalsePositives.razor.cs
@@ -42,6 +42,7 @@ public partial class FalsePositives : IDisposable
     private async Task LoadDetections()
     {
         loadStatus = "Loading records...";
+        detections = null;
         var paginatedResponse = await Service.GetFalseDetectionsAsync(paginationOptions, filterOptions);
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
@@ -66,7 +67,6 @@ public partial class FalsePositives : IDisposable
     private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
     {
         paginationOptions = returnedPaginationOptions;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();
@@ -76,7 +76,6 @@ public partial class FalsePositives : IDisposable
     {
         filterOptions = returnedFilterOptions;
         paginationOptions.Page = 1;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
@@ -47,6 +47,15 @@ public partial class Unknown : IDisposable
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
         pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+
+        if (pagination.TotalNumberOfPages > 0 && paginationOptions.Page > pagination.TotalNumberOfPages)
+        {
+            paginationOptions.Page = pagination.TotalNumberOfPages;
+            paginatedResponse = await Service.GetUnconfirmedDetectionsAsync(paginationOptions, filterOptions);
+            pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
+            pagination.TotalNumberOfPages = paginatedResponse.TotalAmountPages;
+        }
+
         pagination.CurrentPage = paginationOptions.Page;
 
         if (paginatedResponse.Response == null)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Unknown.razor.cs
@@ -42,6 +42,7 @@ public partial class Unknown : IDisposable
     private async Task LoadDetections()
     {
         loadStatus = "Loading records...";
+        detections = null;
         var paginatedResponse = await Service.GetUnconfirmedDetectionsAsync(paginationOptions, filterOptions);
 
         pagination.TotalNumberOfRecords = paginatedResponse.TotalNumberRecords;
@@ -66,7 +67,6 @@ public partial class Unknown : IDisposable
     private async Task ActOnSelectPageCallback(PaginationOptionsDTO returnedPaginationOptions)
     {
         paginationOptions = returnedPaginationOptions;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();
@@ -76,7 +76,6 @@ public partial class Unknown : IDisposable
     {
         filterOptions = returnedFilterOptions;
         paginationOptions.Page = 1;
-        detections = null;
         await LoadDetections();
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         StateHasChanged();


### PR DESCRIPTION
Fixes #608, fixes #624

## Root cause

**#608:** Same shape as #606 - `ActOnSubmitCallback` reloaded the list without clearing `detections` first, so a submit that emptied the list left the old pager rendered under the "No records found" message.

**#624:** Same shape as #604 (fixed on Candidates) `LoadDetections()` never clamped an out-of-range page, so moderating away the last record on the last page left you stuck requesting a page that no longer exists.

Fixing #608 alone would remove the stale pager that currently gives moderators an accidental way back to page 1 - 
So, both are fixed together here. Also added the missing `paginationOptions.Page = 1` reset to Confirmed's `ActOnApplyFilterCallback`, which Unknown and FalsePositives already had.

## Fix

- Move `detections = null` into `LoadDetections()` so every caller clears it consistently, including submit.
- Port the clamp-and-refetch logic from `Candidates.razor.cs` into all three pages.
- Reset page to 1 on filter change in Confirmed.

## Testing

Reproduced both bugs locally, confirmed fixed after the change.
