### PR TITLE
Phone moderating: keep the spectrogram in view, open the next candidate at its top, and tidy the card details

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -54,7 +54,7 @@
                 <!-- Spectrogram Button and Timer -->
                 <div class="row d-flex flex-row justify-content-between m-0 col-12 px-0 detection-player">
                     <div class="px-0">
-                        <a class="" @onclick="@((()=>ToggleCardPlayer()))">
+                        <a class="detection-play" @onclick="@((()=>ToggleCardPlayer()))">
                             <i id=@CardPlayButtonId class="fas fa-play-circle fa-3x"></i>
                         </a>
                     </div>
@@ -107,12 +107,12 @@
                     <Authorized Context="Auth">
                         <!-- Detection Confirmed -->
                         <div class="row">
-                            <div class="col-12 form-group">
-                                <label class="mb-0">Was there an SRKW call in this clip?</label>
-                                <div style="display: grid">
+                            <div class="col-12 form-group detection-section">
+                                <label class="detection-section-title">Was there an SRKW call in this clip?</label>
+                                <div class="detection-options">
                                     @foreach (var option in optionList)
                                     {
-                                        <label>
+                                        <label class="btn btn-sm btn-outline-primary @(Detection.Found.ToLower() == option.ToLower() ? "active" : "")">
                                             <input type="radio"
                                                name="found"
                                                value="@option"
@@ -127,20 +127,20 @@
                         </div>
                         <!-- Tags -->
                         <div class="row">
-                            <div class="col-12 form-group">
-                                <label>Tags</label>
+                            <div class="col-12 form-group detection-section">
+                                <label class="detection-section-title">Tags</label>
                                 <div class="row">
                                     @foreach (var suggestion in GetSuggestedTagList(Detection))
                                     {
                                         <button type="button"
-                                                class="btn btn-sm btn-outline-primary mr-1 mb-1"
+                                                class="btn btn-sm btn-outline-primary"
                                                 @onclick="(() => AddTag(suggestion))">
                                             + @suggestion
                                         </button>
                                     }
                                 </div>
                                 <div class="row">
-                                    <InputText class="form-control" placeholder="Add tags separated by commas or semicolons"
+                                    <InputText class="form-control" placeholder="Separated by commas or semicolons"
                                                Value="@Detection.Tags"
                                                ValueChanged="@OnTagsChanged"
                                                ValueExpression="(() => Detection.Tags)" />
@@ -149,7 +149,7 @@
                                     @foreach (var tag in Detection.TagList)
                                     {
                                         <button type="button"
-                                                class="btn btn-sm btn-outline-primary mr-1 mb-1"
+                                                class="btn btn-sm btn-outline-primary"
                                                 @onclick="(() => RemoveTag(tag))">
                                             x @tag
                                         </button>
@@ -159,8 +159,8 @@
                         </div>
                         <!-- Comments -->
                         <div class="row">
-                            <div class="col-12 form-group">
-                                <label>Comments</label>
+                            <div class="col-12 form-group detection-section">
+                                <label class="detection-section-title">Comments</label>
                                 <div>
                                     <InputTextArea class="form-control"
                                                    placeholder="Add comments"
@@ -288,7 +288,7 @@
                 <!-- Spectrogram Button and Timer -->
                 <div class="row d-flex flex-row justify-content-between m-0 mt-2 px-0 clearfix">
                     <div class="px-0 col">
-                        <a class="" @onclick="@(() => ToggleModalPlayer())">
+                        <a class="detection-play" @onclick="@(() => ToggleModalPlayer())">
                             <i id=@ModalPlayButtonId class="fas fa-play-circle fa-3x"></i>
                         </a>
                     </div>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -36,7 +36,7 @@
 
     <div class="card-body container-fluid">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 order-lg-12">
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 order-lg-12 detection-spectrogram">
                 <!-- Card Spectrogram Image -->
                 <div class="row">
                     <div class="col-12 px-0">

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -138,6 +138,7 @@
                                         <button type="button"
                                                 class="btn btn-sm btn-outline-primary"
                                                 @key="suggestion"
+                                                title="@suggestion"
                                                 @onclick="(() => AddTag(suggestion))">
                                             + @suggestion
                                         </button>
@@ -155,6 +156,7 @@
                                         <button type="button"
                                                 class="btn btn-sm btn-outline-primary"
                                                 @key="tag"
+                                                title="@tag"
                                                 @onclick="(() => RemoveTag(tag))">
                                             x @tag
                                         </button>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -132,8 +132,12 @@
                                 <div class="row">
                                     @foreach (var suggestion in GetSuggestedTagList(Detection))
                                     {
+                                        @* Keyed by the tag: without it Blazor matches these buttons by
+                                           position, so adding one leaves the clicked element in place with
+                                           the next tag's text on it, still focused and looking selected. *@
                                         <button type="button"
                                                 class="btn btn-sm btn-outline-primary"
+                                                @key="suggestion"
                                                 @onclick="(() => AddTag(suggestion))">
                                             + @suggestion
                                         </button>
@@ -150,6 +154,7 @@
                                     {
                                         <button type="button"
                                                 class="btn btn-sm btn-outline-primary"
+                                                @key="tag"
                                                 @onclick="(() => RemoveTag(tag))">
                                             x @tag
                                         </button>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor
@@ -52,7 +52,7 @@
                     </div>
                 </div>
                 <!-- Spectrogram Button and Timer -->
-                <div class="row d-flex flex-row justify-content-between m-0 mt-2 col-12 px-0">
+                <div class="row d-flex flex-row justify-content-between m-0 col-12 px-0 detection-player">
                     <div class="px-0">
                         <a class="" @onclick="@((()=>ToggleCardPlayer()))">
                             <i id=@CardPlayButtonId class="fas fa-play-circle fa-3x"></i>
@@ -65,7 +65,7 @@
                 </div>
 
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 order-lg-0 mt-2 mt-sm-2 mt-md-2">
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 order-lg-0 mt-2 mt-sm-2 mt-md-2 detection-details">
                 <!-- Datetime & Location -->
                 <div class="row">
                     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -177,6 +177,7 @@ public partial class DetectionComponent
         // first render (e.g. while the single detection page is still loading the record);
         // the JS side is idempotent and exits early once the shades exist.
         await JSRuntime.InvokeVoidAsync("DrawRegionShades", _id, Detection.AudioUri, RegionsJson);
+        await JSRuntime.InvokeVoidAsync("WatchCardLayout");
     }
 
     private void SetFoundValue(string found)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -177,7 +177,13 @@ public partial class DetectionComponent
         // first render (e.g. while the single detection page is still loading the record);
         // the JS side is idempotent and exits early once the shades exist.
         await JSRuntime.InvokeVoidAsync("DrawRegionShades", _id, Detection.AudioUri, RegionsJson);
-        await JSRuntime.InvokeVoidAsync("WatchCardLayout");
+
+        // Once per card is enough: the JS wires its listeners on the first call and
+        // re-evaluates every card on each scroll and resize after that.
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("WatchCardLayout");
+        }
     }
 
     private void SetFoundValue(string found)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/DetectionComponent.razor.cs
@@ -377,7 +377,8 @@ public partial class DetectionComponent
         {
             start = annotation.StartTime,
             end = annotation.EndTime,
-            color = "rgba(255, 255, 255, 0.1)"
+            // Outline only (border in ai-for-orcas.css): a fill all but vanished on a small spectrogram
+            color = "rgba(0, 0, 0, 0)"
         }));
 
     private async Task InitializeModalPlayer()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor
@@ -2,7 +2,7 @@
 
     <li>
         <!-- Sidebar - Brand -->
-        <a class="sidebar-brand d-flex align-items-center justify-content-left" href="/">
+        <a class="sidebar-brand d-flex align-items-center" href="/">
             <div>
                 <h4 class="card-title">OrcaHello</h4>
                 <h6 class="card-subtitle sidebar-subtitle">By AI for Orcas</h6>

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Components/SideBarComponent.razor.cs
@@ -5,6 +5,14 @@ public partial class SideBarComponent
     [Inject]
     IJSRuntime JSRuntime { get; set; }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("CollapseSideBarOnSmallScreens");
+        }
+    }
+
     private async Task ToggleDisplay()
     {
         await JSRuntime.InvokeVoidAsync("ToggleSideBar");

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -30,6 +30,9 @@ public partial class Candidates : IDisposable
 
     private string loadStatus = null;
 
+    // Set after a submit; consumed once the re-rendered list is in the DOM.
+    private string _scrollToDetectionId;
+
     protected override async Task OnInitializedAsync()
     {
         await LoadDetections();
@@ -95,6 +98,11 @@ public partial class Candidates : IDisposable
 
     private async Task ActOnSubmitCallback(DetectionUpdate request)
     {
+        // The candidate that takes the submitted card's place is the next one to
+        // moderate; remember where it will be before the list reloads.
+        int submittedIndex = detections?.FindIndex(d => d.Id == request.Id) ?? -1;
+        int pageBefore = paginationOptions.Page;
+
         await Service.UpdateRequestAsync(request);
 
         List<string> leafTags = Detection.GetLeafTags(request.Tags);
@@ -104,6 +112,26 @@ public partial class Candidates : IDisposable
 
         await JSRuntime.InvokeVoidAsync("DestroyActivePlayer");
         await LoadDetections();
+
+        if (submittedIndex >= 0 && detections != null && detections.Count > 0)
+        {
+            // Same page: the card that moved up into the submitted slot (or the
+            // last one, if that slot is gone). A different page: start at its top.
+            int nextIndex = paginationOptions.Page == pageBefore
+                ? Math.Min(submittedIndex, detections.Count - 1)
+                : 0;
+            _scrollToDetectionId = detections[nextIndex].Id;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_scrollToDetectionId != null)
+        {
+            string detectionId = _scrollToDetectionId;
+            _scrollToDetectionId = null;
+            await JSRuntime.InvokeVoidAsync("ScrollCardIntoView", detectionId);
+        }
     }
 
     void IDisposable.Dispose()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Detections/Candidates.razor.cs
@@ -132,6 +132,8 @@ public partial class Candidates : IDisposable
             _scrollToDetectionId = null;
             await JSRuntime.InvokeVoidAsync("ScrollCardIntoView", detectionId);
         }
+
+        await base.OnAfterRenderAsync(firstRender);
     }
 
     void IDisposable.Dispose()

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -72,11 +72,11 @@ label {
 	color: red !important;
 }
 
-/* Candidate card on a tall portrait screen: keep the spectrogram (the evidence) in
-   view while the rest of the card, verdict, tags, comments and buttons, scrolls
-   under it; it releases at the end of the card body. Portrait and below the lg
-   breakpoint only, where the column is stacked full width: sideways the image is
-   most of the viewport, and at lg+ the column sits beside the form. */
+/* Candidate card on a small screen: keep the spectrogram (the evidence) in view
+   while the rest of the card, verdict, tags, comments and buttons, scrolls under
+   it; it releases at the end of the card body. Below the lg breakpoint only, where
+   the column is stacked full width; at lg+ it sits beside the form. Portrait pins
+   it full width; landscape splits the card body in two once scrolled down (below). */
 
 /* sb-admin-2 hides horizontal overflow here, which also makes #content-wrapper the
    scroll container that sticky descendants attach to, so they never reach the
@@ -85,7 +85,7 @@ label {
 	overflow-x: clip;
 }
 
-@media (orientation: portrait) and (max-width: 991.98px) {
+@media (max-width: 991.98px) {
 	.detection-spectrogram {
 		position: sticky;
 		top: 0;
@@ -97,6 +97,138 @@ label {
 		padding-bottom: 0.25rem;
 		box-shadow: 0 0.25rem 0.5rem -0.25rem rgba(0, 0, 0, 0.15);
 	}
+}
+
+/* Landscape: a full-width pinned image would be most of the viewport, so the card
+   starts stacked (evidence first, not pinned) and, once the details have scrolled
+   into the top 30% of the screen, the card body splits side by side: spectrogram
+   pinned at the top on the right (a bit over half), details scrolling on the
+   left, footer full width as before. Scrolling back up past 45% stacks it again
+   (two lines, so it cannot flicker at one position). Class set by
+   UpdateCardLayout in ai-for-orcas.js. Gated on a real landscape width: a portrait
+   phone with the soft keyboard open is also wider than tall, and must not split. */
+@media (orientation: landscape) and (min-width: 568px) and (max-width: 991.98px) {
+	.card:not(.detection-split) .detection-spectrogram {
+		position: static;
+		box-shadow: none;
+	}
+
+	.card.detection-split .detection-spectrogram {
+		/* More than half to the evidence, a little air between the two columns on
+		   top of the gutters */
+		flex: 0 0 55%;
+		max-width: 55%;
+		margin-left: 3%;
+		order: 12;
+		/* Content height, not stretched to the row: a sticky box as tall as its
+		   container has no room to stick */
+		align-self: flex-start;
+		padding-bottom: 0;
+		/* Pinned at the top (base rule) while the details scroll; sticky stops it
+		   at the end of the card body on its own */
+	}
+
+	.card.detection-split .detection-details {
+		flex: 0 0 42%;
+		max-width: 42%;
+		order: 0;
+	}
+
+	/* Narrower details read better as one item per line with tighter spacing */
+	.card.detection-split .detection-details .col-md-6 {
+		flex: 0 0 100%;
+		max-width: 100%;
+	}
+
+	.card.detection-split .detection-details p {
+		margin-bottom: 0.25rem;
+	}
+
+	.card.detection-split .detection-section {
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+
+	/* Smaller play button and timer in the pinned column, so it is mostly spectrogram */
+	.card.detection-split .detection-spectrogram .fa-3x {
+		font-size: 2em;
+	}
+
+	.card.detection-split .detection-spectrogram .h5 {
+		font-size: 1rem;
+	}
+
+	.card.detection-split .detection-player {
+		margin-top: 0.25rem !important;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.card.detection-split .detection-spectrogram {
+			animation: detection-split-in 0.65s cubic-bezier(0.22, 0.61, 0.36, 1);
+		}
+
+		.card.detection-split .detection-details {
+			animation: detection-details-in 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+		}
+
+		.card.detection-stacking .detection-spectrogram {
+			animation: detection-stack-in 0.65s cubic-bezier(0.22, 0.61, 0.36, 1);
+		}
+
+		.card.detection-stacking .detection-details {
+			animation: detection-stack-in 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+		}
+	}
+}
+
+/* A very short viewport (a phone with the soft keyboard open, or a small phone
+   held sideways) has no room for a pinned column over the field being typed in:
+   let the spectrogram scroll like the rest. The split state keeps its own pin. */
+@media (max-height: 479.98px) {
+	.card:not(.detection-split) .detection-spectrogram {
+		position: static;
+		box-shadow: none;
+	}
+}
+
+@keyframes detection-split-in {
+	from {
+		opacity: 0;
+		transform: translateX(0.75rem);
+	}
+
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes detection-details-in {
+	from {
+		opacity: 0;
+		transform: translateX(-0.75rem);
+	}
+
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes detection-stack-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+/* The back-to-top control shares the right edge with a pinned spectrogram column
+   (landscape split); keep it above (sb-admin leaves it at z-index auto) */
+.scroll-to-top {
+	z-index: 6;
 }
 
 /* Blazored toasts are z-index 1; keep them above anything sticky in the cards,

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -71,3 +71,37 @@ label {
 .validation-message {
 	color: red !important;
 }
+
+/* Candidate card on a tall portrait screen: keep the spectrogram (the evidence) in
+   view while the rest of the card, verdict, tags, comments and buttons, scrolls
+   under it; it releases at the end of the card body. Portrait and below the lg
+   breakpoint only, where the column is stacked full width: sideways the image is
+   most of the viewport, and at lg+ the column sits beside the form. */
+
+/* sb-admin-2 hides horizontal overflow here, which also makes #content-wrapper the
+   scroll container that sticky descendants attach to, so they never reach the
+   viewport. clip clips the same way without creating a scroll container. */
+#wrapper #content-wrapper {
+	overflow-x: clip;
+}
+
+@media (orientation: portrait) and (max-width: 991.98px) {
+	.detection-spectrogram {
+		position: sticky;
+		top: 0;
+		/* Above the form controls scrolling under it; the header dropdown (1000)
+		   and modals (1050) stay above */
+		z-index: 5;
+		/* Opaque over the card body (dark theme overrides in sb-admin-2-dark.css) */
+		background-color: #fff;
+		padding-bottom: 0.25rem;
+		box-shadow: 0 0.25rem 0.5rem -0.25rem rgba(0, 0, 0, 0.15);
+	}
+}
+
+/* Blazored toasts are z-index 1; keep them above anything sticky in the cards,
+   below the modal backdrop (1040). Its stylesheet loads after this one, hence
+   the extra specificity. */
+body .blazored-toast-container {
+	z-index: 1030;
+}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -164,6 +164,14 @@ label {
 	cursor: pointer;
 }
 
+/* The input carries the focus but cannot show it, since it is transparent and the
+   button styling sits on the label around it. Draw the ring on the label instead,
+   the same one bootstrap gives a focused .btn. */
+.detection-options label:focus-within {
+	box-shadow: 0 0 0 0.2rem rgba(78, 115, 223, 0.5);
+	border-radius: 0.2rem;
+}
+
 /* Tags read as chips: each one as wide as its own text, so the width says something
    about the tag instead of about how many share the row. Floor keeps a small tag
    tappable, ceiling stops a long one taking the whole row, and what does not fit is

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -96,6 +96,16 @@ label {
 }
 
 @media (max-width: 991.98px) {
+	/* Anything the browser scrolls to (tabbing to the next field, an autofocus, a
+	   restored position) must stop below the pinned column instead of behind it.
+	   ai-for-orcas.js keeps --pinned-height in step with the column. */
+	.detection-details input,
+	.detection-details textarea,
+	.detection-details .btn,
+	.detection-details label {
+		scroll-margin-top: calc(var(--pinned-height, 0px) + 0.5rem);
+	}
+
 	.detection-spectrogram {
 		position: sticky;
 		top: 0;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -316,9 +316,22 @@ label {
 }
 
 /* The back-to-top control shares the right edge with a pinned spectrogram column
-   (landscape split); keep it above (sb-admin leaves it at z-index auto) */
+   (landscape split); keep it above (sb-admin leaves it at z-index auto).
+   sb-admin shows and hides it with queued fadeIn/fadeOut on every scroll event,
+   which on a phone leaves the animation queue behind the finger and the control
+   stuck in the wrong state. ai-for-orcas.js toggles the class below instead, and
+   these rules win over whatever the queue left in the inline style. */
 .scroll-to-top {
 	z-index: 6;
+}
+
+body:not(.show-scroll-to-top) .scroll-to-top {
+	display: none !important;
+}
+
+body.show-scroll-to-top .scroll-to-top {
+	display: block !important;
+	opacity: 1 !important;
 }
 
 /* Blazored toasts are z-index 1; keep them above anything sticky in the cards,

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -363,7 +363,10 @@ body .blazored-toast-container {
    only the scale changes with the room, through the three variables below.
    sb-admin's own rule is a fixed 4.375rem box with 1.5rem of padding, which clips
    the title as soon as the sidebar is narrow. */
-.sidebar-brand {
+/* Scoped like sb-admin's own rule: a bare .sidebar-brand loses to
+   .sidebar .sidebar-brand, which fixes the height at 4.375rem and the padding at
+   1.5rem, so the box could never grow and the rail kept the vendor padding. */
+.sidebar .sidebar-brand {
 	--brand-padding: 1rem;
 	--brand-title: 1.5rem;
 	--brand-subtitle: .8rem;
@@ -374,7 +377,7 @@ body .blazored-toast-container {
 	text-align: center;
 }
 
-.sidebar-brand .card-title {
+.sidebar .sidebar-brand .card-title {
 	font-size: var(--brand-title);
 	/* line-height and the gap are ratios of the type, so the block keeps the same
 	   proportions at every scale */
@@ -383,7 +386,7 @@ body .blazored-toast-container {
 	white-space: nowrap;
 }
 
-.sidebar-brand .sidebar-subtitle {
+.sidebar .sidebar-brand .sidebar-subtitle {
 	font-size: var(--brand-subtitle);
 	line-height: 1.2;
 	/* .card-subtitle pulls itself up by a fixed -.375rem, the same pixels whatever
@@ -397,7 +400,7 @@ body .blazored-toast-container {
    wherever it is the 6.5rem rail (sb-admin uses that width for the whole sidebar
    below md, and for the collapsed sidebar on any screen). */
 @media (max-width: 767.98px) {
-	.sidebar-brand {
+	.sidebar .sidebar-brand {
 		--brand-padding: .5rem;
 		--brand-title: .85rem;
 		--brand-subtitle: .55rem;

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -105,3 +105,64 @@ label {
 body .blazored-toast-container {
 	z-index: 1030;
 }
+
+/* Sidebar on small screens: collapsed from the first paint (body class set by
+   ai-for-orcas.js before Blazor renders), same look as sb-admin's .sidebar.toggled */
+@media (max-width: 767.98px) {
+	body.sidebar-toggled .sidebar {
+		width: 0 !important;
+		overflow: hidden;
+	}
+}
+
+/* Sidebar brand: one block, the same shape wherever it renders (phone or desktop,
+   rail or expanded). Both lines always show and the block grows to hold them;
+   only the scale changes with the room, through the three variables below.
+   sb-admin's own rule is a fixed 4.375rem box with 1.5rem of padding, which clips
+   the title as soon as the sidebar is narrow. */
+.sidebar-brand {
+	--brand-padding: 1rem;
+	--brand-title: 1.5rem;
+	--brand-subtitle: .8rem;
+	height: auto;
+	min-height: 4.375rem;
+	padding: var(--brand-padding);
+	justify-content: center;
+	text-align: center;
+}
+
+.sidebar-brand .card-title {
+	font-size: var(--brand-title);
+	/* line-height and the gap are ratios of the type, so the block keeps the same
+	   proportions at every scale */
+	line-height: 1.2;
+	margin-bottom: .15em;
+	white-space: nowrap;
+}
+
+.sidebar-brand .sidebar-subtitle {
+	font-size: var(--brand-subtitle);
+	line-height: 1.2;
+	/* .card-subtitle pulls itself up by a fixed -.375rem, the same pixels whatever
+	   the type is doing, which is what made the two lines sit differently in each
+	   view. The gap is the title's .15em and nothing else. */
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+/* Two scales, chosen by the room the sidebar has: the wide one above, and this one
+   wherever it is the 6.5rem rail (sb-admin uses that width for the whole sidebar
+   below md, and for the collapsed sidebar on any screen). */
+@media (max-width: 767.98px) {
+	.sidebar-brand {
+		--brand-padding: .5rem;
+		--brand-title: .85rem;
+		--brand-subtitle: .55rem;
+	}
+}
+
+.sidebar.toggled .sidebar-brand {
+	--brand-padding: .5rem;
+	--brand-title: .85rem;
+	--brand-subtitle: .55rem;
+}

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/ai-for-orcas.css
@@ -42,10 +42,20 @@
 	}
 }
 
+/* The play control is an <a> with no href, so the browser leaves the arrow cursor
+   on it and it does not read as clickable on a desktop. */
+.detection-play {
+	cursor: pointer;
+}
+
 /* Wavesurfer additions */
 
+/* Detected regions over the spectrogram: outline only, a magenta 2px edge with a
+   thin dark halo so it reads on both the dark and the light parts of the image at
+   any size (the fill colour from the component is transparent) */
 .wavesurfer-region {
-	border: 1px solid white !important;
+	border: 2px solid rgba(214, 51, 132, 0.95) !important;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
 }
 
 /* Not sure if these help or not */
@@ -97,6 +107,86 @@ label {
 		padding-bottom: 0.25rem;
 		box-shadow: 0 0.25rem 0.5rem -0.25rem rgba(0, 0, 0, 0.15);
 	}
+}
+
+/* Card details: one pattern for every section (verdict, tags, comments): a bold
+   title, then its fields at full width, the same space between sections. The tag
+   rows are .row without a column inside, so their gutters are zeroed and the
+   buttons laid out as an even wrapping grid, text-sized but bounded so the rows
+   fill edge to edge; the input keeps air from the button rows around it. */
+.detection-details p {
+	margin-bottom: 0.5rem;
+}
+
+.detection-section {
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.detection-section-title {
+	display: block;
+	font-weight: 600;
+	margin-bottom: 0.25rem;
+}
+
+.detection-section > .row {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+/* Play button and timer under the spectrogram */
+.detection-player {
+	margin-top: 0.5rem !important;   /* the row's m-0 utility is the one being overridden */
+}
+
+/* Verdict options as buttons on one wrapping line, like the tag rows: the radio
+   input stays inside each button, invisible and covering it, so taps, keyboard
+   and scripts keep driving the radio; the chosen one is filled (.active) */
+.detection-options {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+}
+
+.detection-options label {
+	position: relative;
+	margin-bottom: 0;
+}
+
+.detection-options input[type="radio"] {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	opacity: 0;
+	cursor: pointer;
+}
+
+/* Tags read as chips: each one as wide as its own text, so the width says something
+   about the tag instead of about how many share the row. Floor keeps a small tag
+   tappable, ceiling stops a long one taking the whole row, and what does not fit is
+   cut with an ellipsis rather than wrapped inside the button. */
+.detection-section > .row > .btn {
+	flex: 0 1 auto;
+	min-width: 4.5rem;
+	max-width: 12rem;
+	margin: 0 0.25rem 0.25rem 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.detection-section > .row > .form-control {
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
+	/* Narrow on phones: the placeholder trims with an ellipsis instead of clipping */
+	text-overflow: ellipsis;
+}
+
+.detection-section > .row > .form-control::placeholder {
+	font-size: 0.9rem;
 }
 
 /* Landscape: a full-width pinned image would be most of the viewport, so the card

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/sb-admin-2-dark.css
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/css/sb-admin-2-dark.css
@@ -14,6 +14,11 @@
 .card-body {
 	background-color: #000 !important;
 }
+
+.detection-spectrogram {
+	background-color: #000 !important;
+}
+
 .card-header {
 	background-color: #000 !important;
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -1,12 +1,87 @@
 ﻿/* Sidebar Toggler */
 
+// Below the md breakpoint the topbar hamburger is the way to open the sidebar, so
+// it always starts collapsed there and the content gets the full width. On a larger
+// screen the moderator's last choice is remembered instead.
+var smallScreen = window.matchMedia('(max-width: 767.98px)');
+var sidebarPreferenceKey = 'orcahello.sidebar-collapsed';
+
+function ReadSideBarPreference() {
+	try {
+		return window.localStorage.getItem(sidebarPreferenceKey);
+	} catch (e) {
+		return null;   // private mode, or storage blocked
+	}
+}
+
+function WriteSideBarPreference(collapsed) {
+	try {
+		window.localStorage.setItem(sidebarPreferenceKey, collapsed ? '1' : '0');
+	} catch (e) {
+		// nothing to do, the sidebar just will not remember
+	}
+}
+
+// True when the sidebar should be collapsed for the viewport we are in now.
+function SideBarShouldCollapse() {
+	return smallScreen.matches || ReadSideBarPreference() === '1';
+}
+
+function ApplySideBarState(collapsed) {
+	$("body").toggleClass("sidebar-toggled", collapsed);
+	$(".sidebar").toggleClass("toggled", collapsed);
+	if (collapsed) {
+		$('.sidebar .collapse').collapse('hide');
+	}
+}
+
+function CollapseSideBarOnSmallScreens() {
+
+	ApplySideBarState(SideBarShouldCollapse());
+
+	// Crossing the breakpoint re-decides: into the small range it collapses, back
+	// out of it the remembered choice applies again.
+	var onBreakpoint = function () {
+		ApplySideBarState(SideBarShouldCollapse());
+	};
+
+	if (smallScreen.addEventListener) {
+		smallScreen.addEventListener('change', onBreakpoint);
+	} else {
+		smallScreen.addListener(onBreakpoint);   // Safari before 14
+	}
+
+	// On a small screen the open sidebar covers the page, so a tap on a nav item
+	// would navigate behind it. Close it on the way out. Only for links that leave
+	// the page: the accordion togglers (href="#") and the external ones (target)
+	// keep it open. Namespaced and re-bound so repeated renders leave one handler.
+	$(document).off("click.sidebarnav").on("click.sidebarnav", ".sidebar a", function () {
+		var href = $(this).attr("href");
+		if (!smallScreen.matches || !href || href.charAt(0) === "#" || $(this).attr("target")) {
+			return;
+		}
+		ApplySideBarState(true);
+	});
+}
+
+// This script loads before Blazor renders, so the body class goes on now and the
+// sidebar paints in its final state from the first frame (the css rule on
+// body.sidebar-toggled .sidebar); CollapseSideBarOnSmallScreens then puts the
+// sidebar's own class in step after the first render.
+if (SideBarShouldCollapse()) {
+	document.body.classList.add('sidebar-toggled');
+}
+
 function ToggleSideBar() {
 
-	$("body").toggleClass("sidebar-toggled");
-	$(".sidebar").toggleClass("toggled");
-	if ($(".sidebar").hasClass("toggled")) {
-		$('.sidebar .collapse').collapse('hide');
-	};
+	var collapsed = !$(".sidebar").hasClass("toggled");
+	ApplySideBarState(collapsed);
+
+	// The phone is always collapsed on arrival, so only a real screen records a
+	// preference; otherwise a desktop choice would follow the moderator to the phone.
+	if (!smallScreen.matches) {
+		WriteSideBarPreference(collapsed);
+	}
 
 	ResizeActivePlayer();
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -19,6 +19,8 @@ function UpdateCardLayout() {
 
 	cardLayoutScheduled = false;
 
+	var shift = 0;
+
 	document.querySelectorAll('.detection-spectrogram').forEach(function (column) {
 		var card = column.closest('.card');
 		var row = column.parentElement;
@@ -40,15 +42,18 @@ function UpdateCardLayout() {
 		}
 
 		if (wanted != split) {
-			// Keep the details where the finger is: compensate the scroll by how far
+			// Keep the content where the finger is: compensate the scroll by how far
 			// the details column moved, not by the row height (the narrower column
-			// also gets taller, so the two differ). Exact for the card under the
-			// finger; for cards above it (a rotation, a resize) the error is the
-			// height change of their details column, which is small.
+			// also gets taller, so the two differ). A rotation or a resize switches
+			// every card in one pass, so the shifts are summed and applied once at
+			// the end; a card entirely below the fold moves nothing the moderator
+			// can see and is left out of the sum.
 			var before = details.getBoundingClientRect().top;
 			card.classList.toggle('detection-split', wanted);
 			var after = details.getBoundingClientRect().top;
-			window.scrollBy(0, after - before);
+			if (before < window.innerHeight) {
+				shift += after - before;
+			}
 			ResizeActivePlayer();
 
 			// Lets the css fade the full-width spectrogram back in
@@ -59,6 +64,10 @@ function UpdateCardLayout() {
 			}
 		}
 	});
+
+	if (shift) {
+		window.scrollBy(0, shift);
+	}
 }
 
 function ScheduleCardLayout() {

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -1,4 +1,87 @@
-﻿/* Sidebar Toggler */
+﻿/* Candidate card layout on small landscape screens */
+
+// Stacked at the card top (evidence first); once the details have scrolled into the
+// top part of the screen the card body splits side by side, spectrogram pinned at
+// half width beside the scrolling details. The distance the details move on a
+// switch is compensated on the scroll position, so the content under the finger
+// stays put. One passive scroll listener, one rAF-throttled pass over the cards.
+var cardLayoutScheduled = false;
+var cardLayoutWatching = false;
+var landscapeSmallScreen = window.matchMedia('(orientation: landscape) and (min-width: 568px) and (max-width: 991.98px)');
+// Of the viewport height, from the top. Two different lines so the layout can
+// never flip back and forth at one scroll position: split when the details come
+// up to 30%, stack again only once the row (the details' top edge in the split
+// state) is back down past 45%.
+var SPLIT_WHEN_DETAILS_WITHIN = 0.3;
+var STACK_WHEN_DETAILS_BELOW = 0.45;
+
+function UpdateCardLayout() {
+
+	cardLayoutScheduled = false;
+
+	document.querySelectorAll('.detection-spectrogram').forEach(function (column) {
+		var card = column.closest('.card');
+		var row = column.parentElement;
+		var details = row.querySelector('.detection-details');
+
+		if (!card || !details) {
+			return;
+		}
+
+		var split = card.classList.contains('detection-split');
+		var wanted = split;
+
+		if (!landscapeSmallScreen.matches) {
+			wanted = false;
+		} else if (!split && details.getBoundingClientRect().top <= window.innerHeight * SPLIT_WHEN_DETAILS_WITHIN) {
+			wanted = true;
+		} else if (split && row.getBoundingClientRect().top > window.innerHeight * STACK_WHEN_DETAILS_BELOW) {
+			wanted = false;
+		}
+
+		if (wanted != split) {
+			// Keep the details where the finger is: compensate the scroll by how far
+			// the details column moved, not by the row height (the narrower column
+			// also gets taller, so the two differ). Exact for the card under the
+			// finger; for cards above it (a rotation, a resize) the error is the
+			// height change of their details column, which is small.
+			var before = details.getBoundingClientRect().top;
+			card.classList.toggle('detection-split', wanted);
+			var after = details.getBoundingClientRect().top;
+			window.scrollBy(0, after - before);
+			ResizeActivePlayer();
+
+			// Lets the css fade the full-width spectrogram back in
+			window.clearTimeout(card.stackingTimer);
+			card.classList.toggle('detection-stacking', !wanted);
+			if (!wanted) {
+				card.stackingTimer = window.setTimeout(function () { card.classList.remove('detection-stacking'); }, 700);
+			}
+		}
+	});
+}
+
+function ScheduleCardLayout() {
+
+	if (!cardLayoutScheduled) {
+		cardLayoutScheduled = true;
+		window.requestAnimationFrame(UpdateCardLayout);
+	}
+}
+
+// Called after every card render; wires the listeners once and refreshes the state.
+function WatchCardLayout() {
+
+	if (!cardLayoutWatching) {
+		cardLayoutWatching = true;
+		window.addEventListener('scroll', ScheduleCardLayout, { passive: true });
+		window.addEventListener('resize', ScheduleCardLayout);
+	}
+
+	ScheduleCardLayout();
+}
+
+/* Sidebar Toggler */
 
 // Below the md breakpoint the topbar hamburger is the way to open the sidebar, so
 // it always starts collapsed there and the content gets the full width. On a larger
@@ -435,6 +518,8 @@ function ScrollCardIntoView(detectionId) {
 	var card = image ? image.closest('.card') : null;
 
 	if (card) {
+		// A landscape card lands stacked, evidence first (class set by UpdateCardLayout).
+		card.classList.remove('detection-split');
 		card.scrollIntoView({ block: 'start' });
 	}
 }

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -71,6 +71,32 @@ function UpdateCardLayout() {
 	}
 }
 
+// How much of the screen a pinned column is holding, so anything the browser scrolls
+// to (a tab to the next field, an autofocus, a restored position) can clear it
+// instead of landing underneath. The height only settles once the spectrogram image
+// has loaded, so watch the element rather than measuring once.
+var pinnedHeightObserver = null;
+
+function WatchPinnedHeight() {
+
+	var column = document.querySelector('.detection-spectrogram');
+	if (!column || !window.ResizeObserver) {
+		return;
+	}
+
+	var publish = function () {
+		var height = getComputedStyle(column).position === 'sticky' ? Math.round(column.offsetHeight) : 0;
+		document.documentElement.style.setProperty('--pinned-height', height + 'px');
+	};
+
+	if (pinnedHeightObserver) {
+		pinnedHeightObserver.disconnect();
+	}
+	pinnedHeightObserver = new ResizeObserver(publish);
+	pinnedHeightObserver.observe(column);
+	publish();
+}
+
 function ScheduleCardLayout() {
 
 	if (!cardLayoutScheduled) {
@@ -86,8 +112,10 @@ function WatchCardLayout() {
 		cardLayoutWatching = true;
 		window.addEventListener('scroll', ScheduleCardLayout, { passive: true });
 		window.addEventListener('resize', ScheduleCardLayout);
+		window.addEventListener('resize', WatchPinnedHeight);
 	}
 
+	WatchPinnedHeight();
 	ScheduleCardLayout();
 }
 

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -169,6 +169,49 @@ function ToggleSideBar() {
 	ResizeActivePlayer();
 }
 
+/* Back to top */
+
+// sb-admin drives this control with a queued fadeIn/fadeOut per scroll event, so a
+// fast scroll on a phone leaves the queue running behind the finger and the control
+// visible when it should not be (or the other way round). Decide it from the current
+// scroll position on every frame instead; the css keys off the body class.
+(function () {
+
+	var pending = false;
+
+	var update = function () {
+		pending = false;
+		var top = window.pageYOffset || document.documentElement.scrollTop || 0;
+		document.body.classList.toggle('show-scroll-to-top', top > 100);
+	};
+
+	var onScroll = function () {
+		if (!pending) {
+			pending = true;
+			window.requestAnimationFrame(update);
+		}
+	};
+
+	window.addEventListener('scroll', onScroll, { passive: true });
+	window.addEventListener('resize', onScroll, { passive: true });
+	document.addEventListener('DOMContentLoaded', update);
+	update();
+
+	// sb-admin animates the jump with jQuery easing (easeInOutExpo), and that plugin
+	// is not among the scripts this app loads, so its handler throws and the control
+	// does nothing when tapped. Take the click first and scroll natively. Registered
+	// before sb-admin's, so stopping propagation keeps the broken one from running.
+	document.addEventListener('click', function (event) {
+		var control = event.target.closest ? event.target.closest('.scroll-to-top') : null;
+		if (!control) {
+			return;
+		}
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		window.scrollTo({ top: 0, behavior: 'smooth' });
+	});
+})();
+
 /* Modal Map Functionality */
 
 function LoadBingMap(id, latitude, longitude) {

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -352,6 +352,18 @@ function DrawRegionShades(detectionId, audioUrl, regionsJson) {
 	});
 }
 
+// After a submit re-renders the list, open the next candidate at its card top,
+// spectrogram first, instead of wherever the previous card left the scroll.
+function ScrollCardIntoView(detectionId) {
+
+	var image = document.getElementById('spectrogram-card-' + detectionId);
+	var card = image ? image.closest('.card') : null;
+
+	if (card) {
+		card.scrollIntoView({ block: 'start' });
+	}
+}
+
 // Touch on a card spectrogram that has no player yet: create the player and
 // start playback at the touched point, like the modal spectrogram does. When
 // this card's player already exists, wavesurfer's own click-to-seek on the

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/wwwroot/js/ai-for-orcas.js
@@ -21,6 +21,7 @@ function UpdateCardLayout() {
 
 	var shift = 0;
 
+
 	document.querySelectorAll('.detection-spectrogram').forEach(function (column) {
 		var card = column.closest('.card');
 		var row = column.parentElement;


### PR DESCRIPTION
Fixes #590

Reported by @dbainj1, who moderates on a phone and works from the spectrogram on the card rather than from Details, listening while entering the verdict, tags and comments. Two things got in the way. A card is taller than a phone screen, so by the time you reach the tags the spectrogram has scrolled off. And after a submit the list re-renders with the browser's scroll offset kept, so the next card arrives at its buttons with the spectrogram above the screen. Nothing in the app positioned the viewport; that landing was a side effect of the re-render.

Seven commits, each one change:

1. **Keep the spectrogram in view while a tall card scrolls (portrait).** The spectrogram column sticks to the top of the viewport until the end of the card body, then releases with the card. Applied below the lg breakpoint; landscape at 568px and wider gets the split layout below instead, and desktop is untouched. It applies wherever the detection component renders, which includes Confirmed, Unknown and False Positives.
2. **Open the next candidate at its card top after a submit.** The Candidates page remembers the submitted card's slot and, once the reloaded list has rendered, scrolls the card that took that slot to the top of the viewport. If the reload moves to another page, it starts at that page's first card. Candidates only.
3. **Give the sidebar a phone behaviour and a brand that fits.** Below the md breakpoint it rendered as a 6.5rem icon rail taking a quarter of the screen, while the top bar hamburger is already how it is opened there, so it starts collapsed and the card gets the full width. It closes again when a nav item is tapped, since an open sidebar covers the page it navigated to; submenu togglers and external links leave it open. On a larger screen the last choice is remembered per browser instead. The brand is one block with one set of rules at every width: both lines always show, the box grows rather than clipping the title, and it scales down where the sidebar is narrow.
4. **In landscape, split the card body side by side.** A full-width pinned image would be most of a landscape viewport, so the card starts stacked and switches to spectrogram right, details left once the details reach the top third of the screen, with the buttons still full width. The scroll position is compensated on the switch so the content under the finger stays put, and the two thresholds are separated so it cannot flicker at one position.
5. **Give the card details one layout pattern.** Every section had its own spacing and label weight, and the tag rows are `.row` without a column inside, so their gutters made the tag input and buttons wider than the labels above them. One pattern now covers verdict, tags and comments. The verdict options became buttons on a wrapping line rather than a stacked radio list, which costs much less vertical space on a phone; the radio input stays inside each button, invisible and covering it, so taps, keyboard and assistive tech still drive the radio. Tags read as chips at their own width. Detected regions keep their outline but lose the fill, which all but vanished on a phone-sized spectrogram, and the outline is heavier and magenta with a dark halo so it reads on both light and dark parts of the image. Smaller things in the same pass: the play control gets a pointer cursor (it is an anchor with no href, on every screen), the tag placeholder shortens to "Separated by commas or semicolons", and Blazored toasts move to z-index 1030 so they sit above the pinned column and below the modal backdrop. Applies on every screen.
6. **Stop a tag the moderator did not pick from looking selected.** The tag loops rendered without `@key`, so Blazor matched buttons by position: adding a tag removed it from the suggestions but left the clicked element in place carrying the next tag's text, still focused and still showing the focus ring.
7. **Make back to top appear when it should and actually scroll.** Two defects in the same control. It is shown and hidden with a queued `fadeIn`/`fadeOut` per scroll event, so a fast scroll on a phone leaves the animation queue behind the finger and the control ends up in the wrong state. And the click never worked at all: the jump is animated with jQuery easing (`easeInOutExpo`) and that plugin is not among the scripts the app loads, so the handler threw and the page stayed put.

Checked on a 412x915 touch viewport, at 915x412, and on desktop: the spectrogram stays through the card and releases at its end with touch-to-play still working on it, the next candidate opens at its top after a submit including across a page boundary, the landscape split switches and reverts without flicker, the sidebar starts collapsed and closes on navigation, the success toast stays above the pinned block, dark theme stays solid, and the modals and the card menu still open above it.

Two things worth knowing:

With the on-screen keyboard open the pinned spectrogram leaves the screen. The comment field sits near the end of the card, which is where the pin releases by design, and the viewport hints for keyboard-aware layout did not hold up on a real device. It comes back when the keyboard closes. That gap is tracked separately.

On desktop the next card now jumps to the top of the viewport after each submit, close to where the preserved scroll offset already left it since the card is much shorter there. Browsers older than Safari 16 and Chrome 90 drop `overflow-x: clip`, so the pin is inactive there and nothing else changes.

One rule reaches beyond the card. `#wrapper #content-wrapper` changes from `overflow-x: hidden` to `clip` for the whole app, because `hidden` makes that element a scroll container and captures the sticky column. `clip` clips identically without creating one. Every page inherits it.
