### PR TITLE
Fix Dashboard crash on cold load by loading Chart.js from _Host.cshtml

### DIFF
--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor
@@ -174,9 +174,6 @@
     </div>
 </div>
 
-<script suppress-error="BL9992" src="vendor/chart.js/Chart.min.js"></script>
-
-
 <script suppress-error="BL9992">
 
     Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/Dashboard.razor.cs
@@ -43,8 +43,13 @@ public partial class Dashboard
 
         StateHasChanged();
 
-        await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
-        await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+        // Both charts live inside the section that stays hidden when there is no content,
+        // so drawing them then renders an all-zero doughnut nobody can see.
+        if (metrics.HasContent)
+        {
+            await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
+            await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+        }
     }
 
     private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor
@@ -175,9 +175,6 @@
     </div>
 </div>
 
-<script suppress-error="BL9992" src="vendor/chart.js/Chart.min.js"></script>
-
-
 <script suppress-error="BL9992">
 
     Chart.defaults.global.defaultFontFamily = 'Segoe UI', 'Roboto,"Helvetica Neue",Arial,sans-serif';

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/User/UserActivity.razor.cs
@@ -49,8 +49,13 @@ public partial class UserActivity
 
         StateHasChanged();
 
-        await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
-        await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+        // Both charts live inside the section that stays hidden when there is no content,
+        // so drawing them then renders an all-zero doughnut nobody can see.
+        if (metrics.HasContent)
+        {
+            await JSRuntime.InvokeVoidAsync("DrawDetectionsChart", metrics.DetectionsArray);
+            await JSRuntime.InvokeVoidAsync("DrawDetectionResultsChart", metrics.DetectionResultsArray);
+        }
     }
 
     private async Task ActOnApplyFilterCallback(MetricsFilterDTO returnedFilterOptions)

--- a/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
+++ b/ModeratorFrontEnd/AIForOrcas/AIForOrcas.Client.Web/Pages/_Host.cshtml
@@ -41,8 +41,9 @@
 		<a class="dismiss">🗙</a>
 	</div>
 
-	<!-- Loaded before blazor.server.js so interop functions exist before the circuit's first render -->
+	<!-- Loaded before blazor.server.js so the interop functions and the chart library exist before the circuit's first render -->
 	<script src="~/js/ai-for-orcas.js" asp-append-version="true"></script>
+	<script src="vendor/chart.js/Chart.min.js"></script>
 
 	<script src="_framework/blazor.server.js"></script>
 


### PR DESCRIPTION
Opening the Dashboard on a cold load took the circuit down with `Chart is not defined`, as described in #621.

## What was happening

`Dashboard.razor` loaded `Chart.min.js` from a script tag inside its own markup (line 177) and called `DrawDetectionsChart` from `OnInitializedAsync`. Blazor materialises component markup through the DOM rather than the HTML parser, so a `<script src>` inserted that way gets the force-async flag and does not block whatever the renderer appends next. On a cold load the library had not arrived yet.

That produced two failures, not one. The inline block's first statement, `Chart.defaults.global.defaultFontFamily`, threw `ReferenceError` the moment the block was inserted; the circuit survived that one, but the font defaults were lost. Function declarations are hoisted when a script is evaluated, so `DrawDetectionsChart` was still defined afterwards, and the interop call then failed inside it. That is why the reported stack shows the function rather than a missing-function error, and the reported `<anonymous>:17:9` lines up with `detectionsChart = new Chart(ctx, {`, the seventeenth line of that inline block.

A warm cache hid both, which matches the observation that production and a second page load were fine.

## The change

The library moves to `_Host.cshtml` next to `ai-for-orcas.js`, ahead of `blazor.server.js`, so it is in place before the circuit renders anything. This is the second of the two options in the issue. I went that way rather than moving the calls to `OnAfterRenderAsync` for two reasons: 9249c01 already established this position for the same class of failure, and its commit message records that `OnAfterRenderAsync` can itself fire before a bottom-of-page script finishes loading. Moving the calls also would not have addressed the `Chart.defaults.global` throw, which happens on insertion regardless of when interop runs.

`UserActivity.razor` had the same script tag and the same call path, so it is fixed by the same move. The two pages now share one library tag instead of carrying one each. The trade-off is that Chart.min.js, about 153 KB, now loads on every page rather than only the two chart pages, which is how jQuery and wavesurfer are already served here.

Both code-behinds now skip the chart calls when `metrics.HasContent` is false, as the issue suggested. The charts sit inside the section that stays hidden in that case, so drawing them only produced an all-zero doughnut nobody could see. Worth noting the calls were not failing there: `DetectionsArray` is `"[0, 0]"` when empty, which is valid JSON and Chart.js accepts it. This is wasted work, not a second crash.

## Verification

I could not run the full application locally, since `appsettings.json` ships placeholder AzureAD identifiers and the Dashboard needs the detections API, so I could not perform the empty-cache browser check exactly as the issue describes. Someone with a working environment should confirm that before merging.

What I did verify. The ordering claim the issue flagged as uninstrumented, I tested directly in a browser against this repo's own `Chart.min.js`, using `document.createElement` plus `appendChild` to stand in for how Blazor inserts component markup. With the library tag in the injected markup: `typeof Chart` is `undefined` at call time, an uncaught `ReferenceError: Chart is not defined` fires from the inline block, `DrawDetectionsChart` is nonetheless defined, calling it throws `ReferenceError: Chart is not defined`, and `typeof Chart` is `function` a second and a half later. That last detail matches the issue's report that the library does arrive, just too late. With the library loaded ahead of the injected markup instead, `Chart` is defined at call time, the call succeeds, and the console is clean.

I also ran the CI steps from `AIForOrcas.Client.Web.yaml` locally: restore, `build -c Release -r win-x86`, `test`, and `publish` all pass, and `dotnet format ModeratorFrontEnd/AIForOrcas/AIForOrcas.sln --verify-no-changes` exits clean. Warning count is unchanged at 22 before and after the change, measured on the same machine and command with only the change removed; none of them name the files I touched. One caveat on that: only the .NET 10 SDK is installed here, not 6.0.x, so the build is a compile check against `net6.0` reference assemblies rather than a run on the .NET 6 runtime, and the format check ran under a newer formatter than CI uses.

No tests are included. `AIForOrcas.sln` has no test project, and the failure is browser script-load ordering, which the C# side cannot reproduce; 9249c01 fixed the same class of bug without tests for the same reason.

## Left alone deliberately

`UserActivity.razor` assigns `detections = new Chart(...)` inside `DrawDetectionsChart` (line 194 after this change) where the surrounding code expects `detectionsChart`, so the destroy-before-redraw guard never fires on that page and re-filtering leaks a chart instance. `Dashboard.razor` has the correct name. It is a real bug but a separate one, and folding it into this PR would make both harder to review. Happy to open an issue for it.
