### PR TITLE
ci(inference): add cross-platform component test jobs for audio and model (#437)

### DIFF
--- a/.github/workflows/InferenceSystem.yaml
+++ b/.github/workflows/InferenceSystem.yaml
@@ -37,6 +37,61 @@ jobs:
               - InferenceSystem/**
               - .github/workflows/InferenceSystem.yaml
 
+  # Phase 1 of #437: fast, deterministic component tests (no live HLS).
+  inference-component-test:
+    name: Component tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
+    env:
+      HF_HUB_OFFLINE: "1"
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install FFmpeg (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Install FFmpeg (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ffmpeg -y
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+
+      - name: Cache uv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ runner.os == 'Windows' && '~\AppData\Local\uv\cache' || '~/.cache/uv' }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('InferenceSystem/pyproject.toml', 'InferenceSystem/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        working-directory: InferenceSystem
+        run: uv sync --group dev
+
+      - name: Download HuggingFace model to local cache
+        working-directory: InferenceSystem
+        env:
+          HF_HUB_OFFLINE: "0"
+        run: uv run python -c "from huggingface_hub import snapshot_download; snapshot_download('orcasound/orcahello-srkw-detector-v1')"
+
+      - name: Audio preprocessing component tests
+        working-directory: InferenceSystem
+        run: uv run pytest tests/test_audio_preprocessing.py -v
+
+      - name: Model inference component tests
+        working-directory: InferenceSystem
+        run: uv run pytest tests/test_model_inference.py -v
+
   inference-test-windows:
     runs-on: windows-latest
     needs: changes

--- a/.github/workflows/InferenceSystem.yaml
+++ b/.github/workflows/InferenceSystem.yaml
@@ -53,15 +53,8 @@ jobs:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Install FFmpeg (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-
-      - name: Install FFmpeg (Windows)
-        if: runner.os == 'Windows'
-        run: choco install ffmpeg -y
+      - name: Set up FFmpeg
+        uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6  # v3.1
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
@@ -77,6 +70,12 @@ jobs:
       - name: Install dependencies
         working-directory: InferenceSystem
         run: uv sync --group dev
+
+      - name: Cache Hugging Face models
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ runner.os == 'Windows' && '~\.cache\huggingface\hub' || '~/.cache/huggingface/hub' }}
+          key: ${{ runner.os }}-hf-orcasound-v1
 
       - name: Download HuggingFace model to local cache
         working-directory: InferenceSystem

--- a/.github/workflows/InferenceSystem.yaml
+++ b/.github/workflows/InferenceSystem.yaml
@@ -37,7 +37,7 @@ jobs:
               - InferenceSystem/**
               - .github/workflows/InferenceSystem.yaml
 
-  # Phase 1 of #437: fast, deterministic component tests (no live HLS).
+  # Perform fast, deterministic component tests (no live HLS).
   inference-component-test:
     name: Component tests (${{ matrix.os }})
     strategy:

--- a/InferenceSystem/DEVELOPMENT.md
+++ b/InferenceSystem/DEVELOPMENT.md
@@ -168,6 +168,10 @@ uv run pytest tests/test_model_inference.py::TestParityChecks -v
 
 Tests run via `.github/workflows/InferenceSystem.yaml`.
 
+- **Component tests** (Ubuntu + Windows): `tests/test_audio_preprocessing.py` and `tests/test_model_inference.py`. These are deterministic and use committed fixtures / Hugging Face model weights only.
+- **Integration tests** (Ubuntu + Windows): `tests/test_orchestrator.py` (positive, negative, fail, and Live HLS smoke).
+- **Docker smoke**: builds the inference image and runs a short Live HLS container check.
+
 ## Inference Orchestrator
 
 See [README.md](README.md#quick-start-live-inference-orchestrator) for a quick start on running the orchestrator locally. The entry point is [src/LiveInferenceOrchestrator.py](src/LiveInferenceOrchestrator.py), which streams HLS audio from Orcasound's S3 buckets via the internal `orcasound_hls` module, runs the SRKW detector model on each segment, and uploads positive detections to the OrcaHello Azure backend. 

--- a/InferenceSystem/pyproject.toml
+++ b/InferenceSystem/pyproject.toml
@@ -46,3 +46,10 @@ dev = [
     "pytest==9.0.3",
     "pytest-cov==7.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "parity: compare outputs against committed FastAI references",
+    "slow: long-running tests",
+]


### PR DESCRIPTION
### Description
Resolves part of #437.

This PR integrates the fast, deterministic component unit tests (`test_audio_preprocessing.py` and `test_model_inference.py`) into the inference CI workflow across Ubuntu and Windows runners.

### Key Changes
- Added a dedicated `inference-component-test` CI matrix job that executes `tests/test_audio_preprocessing.py` (audio loading, mel spectrograms, padding/cropping) and `tests/test_model_inference.py` (tensors, shapes, and threshold parity) on `ubuntu-latest` and `windows-latest`.
- Ensures unit test coverage runs automatically on push and PRs without requiring live HLS streaming or cloud credentials.
- Documented the component vs integration vs Docker CI split in `InferenceSystem/DEVELOPMENT.md`.
- Registered pytest `testpaths` and existing markers in `pyproject.toml`.

### Verification
- Ran `uv run pytest tests/test_audio_preprocessing.py tests/test_model_inference.py -v` locally on Windows/CPU.
- Result: **17 passed, 1 skipped** (`test_from_checkpoint` skips when the optional local `model_v1.pt` is absent). All audio loading, mel spectrogram, padding/cropping, and model shape assertion tests passed.

### Test plan
- [ ] Confirm the new `Component tests (ubuntu-latest)` and `Component tests (windows-latest)` jobs run on this PR
- [ ] Confirm existing orchestrator and Docker jobs are unchanged
- [ ] Confirm the path filter still skips inference CI when only unrelated files change